### PR TITLE
Grafana

### DIFF
--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -191,8 +191,8 @@ class Grafana:
                 elif "Invalid API key" in error_message:
                     raise ValueError("Invalid API key")
                 elif (
-                        "A dashboard with the same name in the folder already exists"
-                        in error_message
+                    "A dashboard with the same name in the folder already exists"
+                    in error_message
                 ):
                     raise ValueError("Dashboard with the same name already exists")
                 else:
@@ -219,10 +219,10 @@ class Grafana:
         return False
 
     def delete_dashboard_by_name(self, name):
-        endpoint = os.path.join(self.hostname, "api/dashboards/db",
-                                name.lower().replace(" ", "-"))
-        response = requests.get(
-            url=endpoint, auth=("api_key", self.api_token))
+        endpoint = os.path.join(
+            self.hostname, "api/dashboards/db", name.lower().replace(" ", "-")
+        )
+        response = requests.get(url=endpoint, auth=("api_key", self.api_token))
 
         dashboard = response.json().get("dashboard")
         if dashboard:
@@ -375,8 +375,8 @@ class Grafana:
         SELECT \"timestamp\" AS \"time\",
         {fields_query}
         FROM ag_data_agmeasurement
-        WHERE $__timeFilter(\"timestamp\") AND sensor_id_id={sensor_id} AND  
-"event_uuid_id"='{event.uuid}' \n
+        WHERE $__timeFilter(\"timestamp\") AND sensor_id_id={sensor_id} AND
+        "event_uuid_id"='{event.uuid}' \n
         """
 
         # Build a panel dict for the new panel

--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -191,8 +191,8 @@ class Grafana:
                 elif "Invalid API key" in error_message:
                     raise ValueError("Invalid API key")
                 elif (
-                    "A dashboard with the same name in the folder already exists"
-                    in error_message
+                        "A dashboard with the same name in the folder already exists"
+                        in error_message
                 ):
                     raise ValueError("Dashboard with the same name already exists")
                 else:
@@ -319,17 +319,19 @@ class Grafana:
         except KeyError:
             return False
 
-    def add_panel(self, sensor, uid):
+    def add_panel(self, sensor, event, dashboard_uid):
         """
 
         Adds a new panel for the sensor based on its SensorType.
         The database for the new panel will be whichever database is currently in
         GFConfig. The panel will be placed in the next available slot on the dashboard.
 
-        :param sensor: AGSensor object's sensor type will be used to create the
-        SQL query for the new panel.
+        :param sensor: AGSensor object for this panel (panel will only display sensor
+         data for this sensor type.
+        :param event: Event object for this panel (panel will only display sensor
+        data for this event)
+        :param dashboard_uid: UID of the target dashboard
 
-        :param uid: UID of the target dashboard
         :return: New panel with SQL query based on sensor type
         will be added to dashboard.
         """
@@ -343,7 +345,7 @@ class Grafana:
             field_array.append(field)
 
         # Retrieve current dashboard structure
-        dashboard_info = self.get_dashboard_with_uid(uid)
+        dashboard_info = self.get_dashboard_with_uid(dashboard_uid)
 
         if dashboard_info is None:
             raise ValueError("Dashboard uid not found.")
@@ -385,7 +387,8 @@ class Grafana:
         SELECT \"timestamp\" AS \"time\",
         {fields_query}
         FROM ag_data_agmeasurement
-        WHERE $__timeFilter(\"timestamp\") AND sensor_id_id={sensor_id}\n
+        WHERE $__timeFilter(\"timestamp\") AND sensor_id_id={sensor_id} AND  
+"event_uuid_id"='{event.uuid}' \n
         """
 
         # Build a panel dict for the new panel

--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -218,6 +218,18 @@ class Grafana:
             return True
         return False
 
+    def delete_dashboard_by_name(self, name):
+        endpoint = os.path.join(self.hostname, "api/dashboards/db",
+                                name.lower().replace(" ", "-"))
+        response = requests.get(
+            url=endpoint, auth=("api_key", self.api_token))
+
+        dashboard = response.json().get("dashboard")
+        if dashboard:
+            return self.delete_dashboard(dashboard["uid"])
+        else:
+            return False
+
     def delete_all_dashboards(self):
         """
         Deletes all dashboards associated with the current hostname of the class.
@@ -242,7 +254,7 @@ class Grafana:
         else:
             return False
 
-    def create_postgres_datasource(self):
+    def create_postgres_datasource(self, title="Datasource"):
         """
         Creates a new postgres datasource with the provided credentials:
         - Grafana name
@@ -262,7 +274,7 @@ class Grafana:
         db = {
             "id": None,
             "orgId": None,
-            "name": self.database_grafana_name,
+            "name": title,
             "type": "postgres",
             "access": "proxy",
             "url": self.database_hostname,

--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -401,12 +401,18 @@ class Grafana:
 
         # POST updated dashboard
         headers = {"Content-Type": "application/json"}
-        requests.post(
+        response = requests.post(
             self.endpoints["dashboard_post"],
             data=json.dumps(updated_dashboard),
             headers=headers,
             auth=("api_key", self.api_token),
         )
+
+        try:
+            if response.json()["status"] != "success":
+                raise ValueError(f"Sensor panel not added: {sensor.name}")
+        except KeyError as error:
+            raise ValueError(f"Sensor panel not added: {error}")
 
     def delete_all_panels(self, uid):
         """

--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -230,30 +230,6 @@ class Grafana:
         else:
             return False
 
-    def delete_all_dashboards(self):
-        """
-        Deletes all dashboards associated with the current hostname of the class.
-
-        :return: Returns true if all dashboards were found and deleted. Returns
-        false if no dashboards were found.
-        """
-        search_endpoint = os.path.join(self.endpoints["search"])
-        headers = {"Content-Type": "application/json"}
-        response = requests.get(
-            url=search_endpoint, auth=("api_key", self.api_token), headers=headers
-        )
-
-        dashboards = response.json()
-
-        deleted = True
-        if len(dashboards) > 0:
-            for dashboard in dashboards:
-                deleted = deleted and self.delete_dashboard(dashboard["uid"])
-            # Only return True if there were dashboards to delete and all were deleted
-            return deleted
-        else:
-            return False
-
     def create_postgres_datasource(self, title="Datasource"):
         """
         Creates a new postgres datasource with the provided credentials:

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -7,6 +7,8 @@ from mercury.grafanaAPI.grafana_api import Grafana
 import requests
 import os
 import datetime
+import random
+import string
 
 
 # default host and token, use this if user did not provide anything
@@ -76,7 +78,6 @@ class TestGrafana(TestCase):
 
         return event
 
-
     def setUp(self):
         self.login_url = "mercury:EventAccess"
         self.sensor_url = "mercury:sensor"
@@ -86,20 +87,25 @@ class TestGrafana(TestCase):
         # Login
         self._get_with_event_code(self.sensor_url, self.TESTCODE)
 
-        # Create fresh grafana instance
+        # Create fresh grafana object
         self.grafana = Grafana(HOST, TOKEN)
 
-        # Clear all of existing dashboards
-        #self.grafana.delete_all_dashboards()
-        #self.grafana.delete_datasource_by_name(self.grafana.database_grafana_name)
+        # Create random name to be used for event and datasource
+        letters = string.ascii_lowercase
+        self.event_name = ''.join(random.choice(letters) for i in range(10))
+        self.datasource_name = ''.join(random.choice(letters) for i in range(10))
+
+        # Clear existing dashboard and datasource
+        self.grafana.delete_dashboard_by_name(self.event_name)
+        self.grafana.delete_datasource_by_name(self.datasource_name)
 
     def tearDown(self):
         # Create fresh grafana instance (in case test invalidated any tokens, etc.)
         self.grafana = Grafana(HOST, TOKEN)
 
         # Clear all of the created dashboards
-        #self.grafana.delete_all_dashboards()
-        #self.grafana.delete_datasource_by_name(self.grafana.database_grafana_name)
+        self.grafana.delete_dashboard_by_name(self.event_name)
+        self.grafana.delete_datasource_by_name(self.datasource_name)
 
     def _get_with_event_code(self, url, event_code):
         self.client.get(reverse(self.login_url))
@@ -108,8 +114,8 @@ class TestGrafana(TestCase):
         session = self.client.session
         return response, session
 
-    def not_test_get_dashboard_exists(self):
-        dashboard = self.grafana.create_dashboard(self.title)
+    def test_get_dashboard_exists(self):
+        dashboard = self.grafana.create_dashboard(self.event_name)
 
         self.assertTrue(dashboard)
 
@@ -119,29 +125,30 @@ class TestGrafana(TestCase):
 
         self.assertTrue(fetched_dashboard)
         self.assertTrue(fetched_dashboard["meta"])
-        self.assertTrue(fetched_dashboard["meta"]["slug"], self.title.lower())
+        self.assertTrue(fetched_dashboard["meta"]["slug"], self.event_name.lower())
         self.assertTrue(fetched_dashboard["dashboard"])
         self.assertTrue(fetched_dashboard["dashboard"]["uid"], uid)
-        self.assertTrue(fetched_dashboard["dashboard"]["title"], self.title)
+        self.assertTrue(fetched_dashboard["dashboard"]["title"], self.event_name)
 
-    def not_test_get_dashboard_fail(self):
-        uid = "abcde"  # doesn't exist
+    def test_get_dashboard_fail(self):
+        letters = string.ascii_lowercase
+        uid = ''.join(random.choice(letters) for i in range(10))
 
         fetched_dashboard = self.grafana.get_dashboard_with_uid(uid)
 
         self.assertFalse(fetched_dashboard)
 
-    def not_test_create_grafana_dashboard_success(self):
-        dashboard = self.grafana.create_dashboard(self.title)
+    def test_create_grafana_dashboard_success(self):
+        dashboard = self.grafana.create_dashboard(self.event_name)
 
         self.assertTrue(dashboard)
 
-    def not_test_create_grafana_dashboard_verify_new_dashboard_contents(self):
-        dashboard = self.grafana.create_dashboard(self.title)
+    def test_create_grafana_dashboard_verify_new_dashboard_contents(self):
+        dashboard = self.grafana.create_dashboard(self.event_name)
 
         self.assertTrue(dashboard)
         self.assertEquals(dashboard["status"], "success")
-        self.assertEquals(dashboard["slug"], self.title.lower())
+        self.assertEquals(dashboard["slug"], self.event_name.lower())
         uid = dashboard["uid"]
 
         # confirm new dashboard can be queried from the API
@@ -152,25 +159,25 @@ class TestGrafana(TestCase):
         )
 
         self.assertEquals(response.json()["dashboard"]["uid"], uid)
-        self.assertEquals(response.json()["dashboard"]["title"], self.title)
+        self.assertEquals(response.json()["dashboard"]["title"], self.event_name)
 
-    def not_test_create_grafana_dashboard_fail_authorization(self):
+    def test_create_grafana_dashboard_fail_authorization(self):
         self.grafana.api_token = "abcde"  # invalidate API token
 
         expected_message = "Invalid API key"
         with self.assertRaisesMessage(ValueError, expected_message):
-            self.grafana.create_dashboard(self.title)
+            self.grafana.create_dashboard(self.event_name)
 
-    def not_test_create_grafana_dashboard_fail_duplicate_title(self):
-        dashboard = self.grafana.create_dashboard(self.title)
+    def test_create_grafana_dashboard_fail_duplicate_title(self):
+        dashboard = self.grafana.create_dashboard(self.event_name)
         self.assertTrue(dashboard)
 
         expected_message = "Dashboard with the same name already exists"
         with self.assertRaisesMessage(ValueError, expected_message):
-            self.grafana.create_dashboard(self.title)
+            self.grafana.create_dashboard(self.event_name)
 
-    def not_test_delete_grafana_dashboard(self):
-        dashboard = self.grafana.create_dashboard(self.title)
+    def test_delete_grafana_dashboard(self):
+        dashboard = self.grafana.create_dashboard(self.event_name)
         self.assertTrue(dashboard)
 
         deleted_dashboard = self.grafana.delete_dashboard(dashboard["uid"])
@@ -188,13 +195,17 @@ class TestGrafana(TestCase):
         self.assertTrue(response.json()["message"])
         self.assertEquals(response.json()["message"], "Dashboard not found")
 
-    def not_test_add_panel(self):
-        dashboard = self.grafana.create_dashboard(self.title)
+    def test_add_panel(self):
+        dashboard = self.grafana.create_dashboard(self.event_name)
         self.assertTrue(dashboard)
         uid = dashboard["uid"]
 
         self.sim.createOrResetASensorTypeFromPresets(0)
         self.sim.createASensorFromPresets(0)
+        self.sim.createAVenueFromPresets(0)
+        self.sim.createAnEventFromPresets(0)
+        events = AGEvent.objects.all()
+        event = events[0]
 
         dashboard_info = self.grafana.get_dashboard_with_uid(uid)
         try:
@@ -214,7 +225,7 @@ class TestGrafana(TestCase):
         )
         sensor.save()
 
-        self.grafana.add_panel(sensor, uid)
+        self.grafana.add_panel(sensor, event, uid)
 
         dashboard_info = self.grafana.get_dashboard_with_uid(uid)
 
@@ -226,36 +237,36 @@ class TestGrafana(TestCase):
             dashboard_info["dashboard"]["panels"][0]["title"] == sensor.name
         )
 
-    def not_test_create_postgres_datasource(self):
+    def test_create_postgres_datasource(self):
         # create datasource
-        self.grafana.create_postgres_datasource()
+        self.grafana.create_postgres_datasource(self.datasource_name)
 
         # confirm that the datasource exists
         endpoint = os.path.join(
             self.grafana.endpoints["datasource_name"],
-            self.grafana.database_grafana_name,
+            self.datasource_name,
         )
         headers = {"Content-Type": "application/json"}
         response = requests.get(
             url=endpoint, headers=headers, auth=("api_key", self.grafana.api_token)
         )
 
-        self.assertEquals(response.json()["name"], self.grafana.database_grafana_name)
+        self.assertEquals(response.json()["name"], self.datasource_name)
 
-    def not_test_delete_postgres_datasource(self):
+    def test_delete_postgres_datasource(self):
         # create the datasource
-        self.grafana.create_postgres_datasource()
+        self.grafana.create_postgres_datasource(self.datasource_name)
 
         # deleted should be true if delete_datasource_by_name returns true
         deleted = self.grafana.delete_datasource_by_name(
-            self.grafana.database_grafana_name
+            self.datasource_name
         )
         self.assertTrue(deleted)
 
         # figure out whether the datasource was actually deleted
         endpoint = os.path.join(
             self.grafana.endpoints["datasource_name"],
-            self.grafana.database_grafana_name,
+            self.datasource_name,
         )
         headers = {"Content-Type": "application/json"}
         response = requests.get(
@@ -265,13 +276,15 @@ class TestGrafana(TestCase):
         self.assertTrue(response.json()["message"])
         self.assertEquals(response.json()["message"], "Data source not found")
 
-    def not_test_create_event_creates_dashboard_no_panels(self):
+    def test_create_event_creates_dashboard_no_panels(self):
         # create a GFConfig object (if one doesn't exist no dashboard would be created)
         self.create_gfconfig()
 
+        self.grafana.create_postgres_datasource(self.datasource_name)
+
         # create a venue
         venue = AGVenue.objects.create(
-            name=self.test_venue_data["name"],
+            name=self.event_name,
             description=self.test_venue_data["description"],
             latitude=self.test_venue_data["latitude"],
             longitude=self.test_venue_data["longitude"]
@@ -284,7 +297,7 @@ class TestGrafana(TestCase):
             reverse(self.event_url),
             data={
                 "submit-event": "",
-                "name": self.test_event_data["name"],
+                "name": self.event_name,
                 "date": self.test_event_data["date"],
                 "description": self.test_event_data["description"],
                 "venue_uuid": venue.uuid,
@@ -293,9 +306,8 @@ class TestGrafana(TestCase):
 
         # if there are spaces in the name, Grafana will replace them with dashes
         # for the slug, which is what you use to query the grafana api by dashboard name
-        endpoint = os.path.join(self.grafana.hostname, "api/dashboards/db", \
-                                               self.test_event_data[
-            "name"].lower().replace(" ", "-"))
+        endpoint = os.path.join(self.grafana.hostname, "api/dashboards/db",
+                                self.event_name.lower().replace(" ", "-"))
 
         response = requests.get(
             url=endpoint, auth=("api_key", self.grafana.api_token)
@@ -303,14 +315,13 @@ class TestGrafana(TestCase):
 
         # confirm that a dashboard was created with the expected name
         self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.json()["dashboard"]["title"], self.test_event_data[
-            "name"])
+        self.assertEquals(response.json()["dashboard"]["title"], self.event_name)
 
     def test_create_event_creates_dashboard_with_panel(self):
         # create a GFConfig object (if one doesn't exist no dashboard would be created)
         self.create_gfconfig()
 
-        self.grafana.create_postgres_datasource()
+        self.grafana.create_postgres_datasource(self.datasource_name)
 
         # create a venue
         venue = AGVenue.objects.create(
@@ -338,7 +349,7 @@ class TestGrafana(TestCase):
             reverse(self.event_url),
             data={
                 "submit-event": "",
-                "name": self.test_event_data["name"],
+                "name": self.event_name,
                 "date": self.test_event_data["date"],
                 "description": self.test_event_data["description"],
                 "venue_uuid": venue.uuid,
@@ -348,8 +359,7 @@ class TestGrafana(TestCase):
         # if there are spaces in the name, Grafana will replace them with dashes
         # for the slug, which is what you use to query the grafana api by dashboard name
         endpoint = os.path.join(self.grafana.hostname, "api/dashboards/db", \
-                                self.test_event_data[
-                                    "name"].lower().replace(" ", "-"))
+                                self.event_name.lower().replace(" ", "-"))
 
         response = requests.get(
             url=endpoint, auth=("api_key", self.grafana.api_token)
@@ -357,8 +367,7 @@ class TestGrafana(TestCase):
 
         # confirm that a dashboard was created with the expected name
         self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.json()["dashboard"]["title"], self.test_event_data[
-            "name"])
+        self.assertEquals(response.json()["dashboard"]["title"], self.event_name)
 
         # confirm that the sql query for the created panel contains the event UUID
         dashboard_info = self.grafana.get_dashboard_with_uid(response.json()[

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -51,11 +51,7 @@ class TestGrafana(TestCase):
     }
 
     def create_gfconfig(self):
-        config = GFConfig.objects.create(
-            gf_host=HOST,
-            gf_token=TOKEN,
-            gf_current=True,
-        )
+        config = GFConfig.objects.create(gf_host=HOST, gf_token=TOKEN, gf_current=True,)
         config.save()
         return config
 
@@ -64,7 +60,7 @@ class TestGrafana(TestCase):
             name=self.test_venue_data["name"],
             description=self.test_venue_data["description"],
             latitude=self.test_venue_data["latitude"],
-            longitude=self.test_venue_data["longitude"]
+            longitude=self.test_venue_data["longitude"],
         )
         venue.save()
 
@@ -72,7 +68,7 @@ class TestGrafana(TestCase):
             name=self.test_event_data["name"],
             date=self.test_event_data["date"],
             description=self.test_event_data["description"],
-            venue_uuid=venue.uuid
+            venue_uuid=venue.uuid,
         )
         event.save()
 
@@ -92,8 +88,8 @@ class TestGrafana(TestCase):
 
         # Create random name to be used for event and datasource
         letters = string.ascii_lowercase
-        self.event_name = ''.join(random.choice(letters) for i in range(10))
-        self.datasource_name = ''.join(random.choice(letters) for i in range(10))
+        self.event_name = "".join(random.choice(letters) for i in range(10))
+        self.datasource_name = "".join(random.choice(letters) for i in range(10))
 
         # Clear existing dashboard and datasource
         self.grafana.delete_dashboard_by_name(self.event_name)
@@ -132,7 +128,7 @@ class TestGrafana(TestCase):
 
     def test_get_dashboard_fail(self):
         letters = string.ascii_lowercase
-        uid = ''.join(random.choice(letters) for i in range(10))
+        uid = "".join(random.choice(letters) for i in range(10))
 
         fetched_dashboard = self.grafana.get_dashboard_with_uid(uid)
 
@@ -243,8 +239,7 @@ class TestGrafana(TestCase):
 
         # confirm that the datasource exists
         endpoint = os.path.join(
-            self.grafana.endpoints["datasource_name"],
-            self.datasource_name,
+            self.grafana.endpoints["datasource_name"], self.datasource_name,
         )
         headers = {"Content-Type": "application/json"}
         response = requests.get(
@@ -258,15 +253,12 @@ class TestGrafana(TestCase):
         self.grafana.create_postgres_datasource(self.datasource_name)
 
         # deleted should be true if delete_datasource_by_name returns true
-        deleted = self.grafana.delete_datasource_by_name(
-            self.datasource_name
-        )
+        deleted = self.grafana.delete_datasource_by_name(self.datasource_name)
         self.assertTrue(deleted)
 
         # figure out whether the datasource was actually deleted
         endpoint = os.path.join(
-            self.grafana.endpoints["datasource_name"],
-            self.datasource_name,
+            self.grafana.endpoints["datasource_name"], self.datasource_name,
         )
         headers = {"Content-Type": "application/json"}
         response = requests.get(
@@ -287,7 +279,7 @@ class TestGrafana(TestCase):
             name=self.event_name,
             description=self.test_venue_data["description"],
             latitude=self.test_venue_data["latitude"],
-            longitude=self.test_venue_data["longitude"]
+            longitude=self.test_venue_data["longitude"],
         )
         venue.save()
 
@@ -306,12 +298,13 @@ class TestGrafana(TestCase):
 
         # if there are spaces in the name, Grafana will replace them with dashes
         # for the slug, which is what you use to query the grafana api by dashboard name
-        endpoint = os.path.join(self.grafana.hostname, "api/dashboards/db",
-                                self.event_name.lower().replace(" ", "-"))
-
-        response = requests.get(
-            url=endpoint, auth=("api_key", self.grafana.api_token)
+        endpoint = os.path.join(
+            self.grafana.hostname,
+            "api/dashboards/db",
+            self.event_name.lower().replace(" ", "-"),
         )
+
+        response = requests.get(url=endpoint, auth=("api_key", self.grafana.api_token))
 
         # confirm that a dashboard was created with the expected name
         self.assertEquals(response.status_code, 200)
@@ -328,7 +321,7 @@ class TestGrafana(TestCase):
             name=self.test_venue_data["name"],
             description=self.test_venue_data["description"],
             latitude=self.test_venue_data["latitude"],
-            longitude=self.test_venue_data["longitude"]
+            longitude=self.test_venue_data["longitude"],
         )
         venue.save()
 
@@ -358,20 +351,22 @@ class TestGrafana(TestCase):
 
         # if there are spaces in the name, Grafana will replace them with dashes
         # for the slug, which is what you use to query the grafana api by dashboard name
-        endpoint = os.path.join(self.grafana.hostname, "api/dashboards/db", \
-                                self.event_name.lower().replace(" ", "-"))
-
-        response = requests.get(
-            url=endpoint, auth=("api_key", self.grafana.api_token)
+        endpoint = os.path.join(
+            self.grafana.hostname,
+            "api/dashboards/db",
+            self.event_name.lower().replace(" ", "-"),
         )
+
+        response = requests.get(url=endpoint, auth=("api_key", self.grafana.api_token))
 
         # confirm that a dashboard was created with the expected name
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.json()["dashboard"]["title"], self.event_name)
 
         # confirm that the sql query for the created panel contains the event UUID
-        dashboard_info = self.grafana.get_dashboard_with_uid(response.json()[
-                                                                 "dashboard"]["uid"])
+        dashboard_info = self.grafana.get_dashboard_with_uid(
+            response.json()["dashboard"]["uid"]
+        )
 
         # confirm that a the new dashboard can be queried and has panel with correct
         # title

--- a/mercury/views/events.py
+++ b/mercury/views/events.py
@@ -163,7 +163,7 @@ class CreateEventsView(TemplateView):
                     sensors = AGSensor.objects.all()
                     for sensor in sensors:
                         try:
-                            grafana.add_panel(sensor, dashboard_uid)
+                            grafana.add_panel(sensor, event_data, dashboard_uid)
                         except ValueError as error:
                             # pass any error messages from the API to the UI
                             messages.error(request, error)

--- a/mercury/views/events.py
+++ b/mercury/views/events.py
@@ -8,6 +8,9 @@ from django.views.generic import TemplateView
 from ..event_check import require_event_code
 from mercury.forms import EventForm, VenueForm
 from ag_data.models import AGMeasurement, AGEvent, AGVenue, AGSensor
+from django.contrib import messages
+from mercury.grafanaAPI.grafana_api import Grafana
+from mercury.models import GFConfig
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.ERROR)
@@ -135,7 +138,35 @@ class CreateEventsView(TemplateView):
                 date=post_event_date,
                 description=post_event_description,
             )
+
             event_data.save()
+
+            gfconfig = GFConfig.objects.filter(gf_current=True)
+
+            # only create an event dashboard if a current gfconfig exists
+            if gfconfig.count() > 0:
+                dashboard = None
+                # create a dashboard with the same name as the event
+                try:
+                    grafana = Grafana()
+                    dashboard = grafana.create_dashboard(post_event_name)
+                except ValueError as error:
+                    # pass any failure message from the API to the UI
+                    messages.error(request, f"Grafana dashboard for this event was not "
+                                            f"created: {error}")
+
+                # if a dashboard was created successfully, add panels to it
+                if dashboard:
+                    # retrieve dashboard uid
+                    dashboard_uid = dashboard["uid"]
+                    # create a panel for each sensor
+                    sensors = AGSensor.objects.all()
+                    for sensor in sensors:
+                        try:
+                            grafana.add_panel(sensor, dashboard_uid)
+                        except ValueError as error:
+                            # pass any error messages from the API to the UI
+                            messages.error(request, error)
 
         events = AGEvent.objects.all().order_by("uuid")
         venues = AGVenue.objects.all().order_by("uuid")

--- a/mercury/views/events.py
+++ b/mercury/views/events.py
@@ -152,8 +152,11 @@ class CreateEventsView(TemplateView):
                     dashboard = grafana.create_dashboard(post_event_name)
                 except ValueError as error:
                     # pass any failure message from the API to the UI
-                    messages.error(request, f"Grafana dashboard for this event was not "
-                                            f"created: {error}")
+                    messages.error(
+                        request,
+                        f"Grafana dashboard for this event was not "
+                        f"created: {error}",
+                    )
 
                 # if a dashboard was created successfully, add panels to it
                 if dashboard:


### PR DESCRIPTION
1. Update test suite so that tests can run concurrently in the same Grafana instance without interfering with one another. Removed destructive operation delete_all_dashboards from the Grafana API and replaced with delete_by_dashboard_name. When a new Test instance is created, it generates a random dashboard/event name and datasource name to use for testing, and only invoked created/delete operations on randomly-generated names, to avoid interference across tests. 
2. Update Create Event feature so that when an event is created, the post view will check if a GFConfig object exists, and if one does, will create a dashboard for the new Event with a panel for each sensor in the AGSensor model. The query for each panel will display only the data for the current event. Test added for this new feature.