### PR TITLE
Grafana API tests, improve error-handling

### DIFF
--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -270,9 +270,6 @@ class Grafana:
             auth=("api_key", self.api_token),
         )
 
-        if response.status_code != 200:
-            raise ValueError(f"Datasource creation failed: {response.reason}")
-
         datasource = response.json()
 
         message = datasource.get("message")
@@ -280,10 +277,12 @@ class Grafana:
             raise ValueError("Response contains no message")
         if "Datasource added" in message:
             return datasource
-        elif "Access denied" in message:
-            raise ValueError("Access denied - check hostname and API token")
         elif "Data source with same name already exists" in message:
             raise ValueError("Datasource with the same name already exists")
+        elif "Permission denied" in message:
+            raise ValueError("Access denied - check API permissions")
+        elif "Invalid API key" in message:
+            raise ValueError("Invalid API key")
         else:
             raise ValueError(f"Create_postgres_datasource() failed: {message}")
 

--- a/mercury/views/gf_config.py
+++ b/mercury/views/gf_config.py
@@ -40,26 +40,16 @@ class GFConfigView(TemplateView):
                 gf_host=request.POST.get("gf_host"),
                 gf_token=request.POST.get("gf_token"),
             )
-            config_data.save()
-
-            # Create Grafana instance with host and token
-            grafana = Grafana(config_data.gf_host, config_data.gf_token)
 
             try:
-                # Create dashboard
-                dashboard = grafana.create_dashboard()
-                # Create grafana panels for any existing sensors
-                for sensor in AGSensor.objects.all():
-                    grafana.add_panel(sensor, dashboard["uid"])
-
-                # If dashboard was created, store its uid in gf_config object
-                # and set current attribute to True
-                config_data.gf_dashboard_uid = dashboard["uid"]
+                # Create Grafana instance with host and token
+                grafana = Grafana(config_data.gf_host, config_data.gf_token)
                 config_data.gf_current = True
+                # Only save the config if credentials were validated
                 config_data.save()
 
             except ValueError as error:
-                messages.error(request, f"Dashboard couldn't be created. {error}")
+                messages.error(request, f"Grafana initial set up failed: {error}")
 
             try:
                 grafana.create_postgres_datasource()

--- a/mercury/views/gf_config.py
+++ b/mercury/views/gf_config.py
@@ -6,7 +6,6 @@ from mercury.forms import GFConfigForm
 from mercury.models import GFConfig
 from mercury.grafanaAPI.grafana_api import Grafana
 from django.contrib import messages
-from ag_data.models import AGSensor
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.ERROR)


### PR DESCRIPTION
- Remove Grafana hook after GFConfig object creation of a dashboard. Dashboards are now created when events are created. 
- Add error-handling tests for invalid API credentials and incorrect API permissions for `create_dashboard()` and `create_datasource()` methods. 
- Add test to create multiple panels at the same time, confirm that all were created with the expected names. 
- Add test that `add_panel()` throws a `ValueError` when an invalid dashboard uid is provided.