### PR TITLE
GFConfig testing; Change Grafana class to take GFConfig in constructor; Fix issue with API tests causing Quota Reached error

### DIFF
--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -89,7 +89,7 @@ class Grafana:
         """
         :param uid: uid of the target dashboard
         :return:
-        Returns dashboard dictionary for given uid:
+        Returns dashboard dictionary for given uid or None if no dashboard was found.
         e.g. {
             'meta':
                 {
@@ -110,8 +110,6 @@ class Grafana:
                 'version': 1
             }
         }
-
-        Returns None if no dashboard is found.
         """
         headers = {"Content-Type": "application/json"}
         endpoint = os.path.join(self.endpoints["dashboard_uid"], uid)

--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -78,7 +78,7 @@ class Grafana:
         self.base_panel_width = 15
         self.base_panel_height = 12
 
-    def generate_random_string(length):
+    def generate_random_string(self, length):
         """
         Generates a random string of letters of length=length
         :param length: Target length for the random string

--- a/mercury/tests/test_gf_configs.py
+++ b/mercury/tests/test_gf_configs.py
@@ -1,0 +1,113 @@
+from django.test import TestCase
+from django.urls import reverse
+from mercury.models import EventCodeAccess, GFConfig
+from ag_data.models import AGSensor, AGSensorType, AGEvent, AGVenue
+from ag_data import simulator
+from mercury.grafanaAPI.grafana_api import Grafana
+import requests
+import os
+import datetime
+
+
+# default host and token, use this if user did not provide anything
+HOST = "https://mercurytests.grafana.net"
+# this token has Admin level permissions
+TOKEN = (
+    "eyJrIjoiUm81MzlOUlRhalhGUFJ5OVVMNTZGTTZIdT"
+    "dvVURDSzIiLCJuIjoiYXBpX2tleSIsImlkIjoxfQ=="
+)
+# this token has Editor level permissions
+EDITOR_TOKEN = (
+    "eyJrIjoibHlrZ2JWY0pnQk94b1YxSGYzd0NJ"
+    "ZUdZa3JBeWZIT3QiLCJuIjoiZWRpdG9yX2tleSIsImlkIjoxfQ=="
+)
+
+
+class TestGrafana(TestCase):
+    TESTCODE = "testcode"
+
+    def setUp(self):
+        self.login_url = "mercury:EventAccess"
+        self.sensor_url = "mercury:sensor"
+        self.event_url = "mercury:events"
+        self.config_url = "mercury:gfconfig"
+        test_code = EventCodeAccess(event_code="testcode", enabled=True)
+        test_code.save()
+        # Login
+        self._get_with_event_code(self.sensor_url, self.TESTCODE)
+
+        # Create fresh grafana object
+        self.grafana = Grafana(HOST, TOKEN)
+
+        # Create random name to be used for event and datasource
+        self.event_name = self.grafana.generate_random_string(10)
+        self.datasource_name = self.grafana.generate_random_string(10)
+
+        # Clear existing dashboard and datasource
+        self.grafana.delete_dashboard_by_name(self.event_name)
+        self.grafana.delete_datasource_by_name(self.datasource_name)
+
+    def tearDown(self):
+        # Create fresh grafana instance (in case test invalidated any tokens, etc.)
+        self.grafana = Grafana(HOST, TOKEN)
+
+        # Clear all of the created dashboards
+        self.grafana.delete_dashboard_by_name(self.event_name)
+        self.grafana.delete_datasource_by_name(self.datasource_name)
+
+    def _get_with_event_code(self, url, event_code):
+        self.client.get(reverse(self.login_url))
+        self.client.post(reverse(self.login_url), data={"eventcode": event_code})
+        response = self.client.get(reverse(url))
+        session = self.client.session
+        return response, session
+
+    def test_config_view_get_success(self):
+        response = self.client.get(reverse(self.config_url))
+        self.assertEqual(200, response.status_code)
+
+    def test_config_post_success(self):
+        response = self.client.post(reverse(self.config_url), data={
+            "submit": "",
+            "gf_name": "Test Grafana Instance",
+            "gf_host": HOST,
+            "gf_token": TOKEN,
+        })
+        self.assertEqual(200, response.status_code)
+
+        gfconfig = GFConfig.objects.all()
+        self.assertTrue(gfconfig.count() > 0)
+        self.assertTrue(gfconfig[0].gf_name == "Test Grafana Instance")
+        self.assertTrue(gfconfig[0].gf_host == HOST)
+        self.assertTrue(gfconfig[0].gf_token == TOKEN)
+
+    def test_config_post_fail_invalid_API_key(self):
+        response = self.client.post(reverse(self.config_url), data={
+            "submit": "",
+            "gf_name": "Test Grafana Instance",
+            "gf_host": HOST,
+            "gf_token": "abcde",
+        })
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, "Grafana API validation failed: Invalid API key")
+
+        gfconfig = GFConfig.objects.all()
+        self.assertTrue(gfconfig.count() == 0)
+
+    def test_config_post_fail_insufficient_permissions(self):
+        response = self.client.post(reverse(self.config_url), data={
+            "submit": "",
+            "gf_name": "Test Grafana Instance",
+            "gf_host": HOST,
+            "gf_token": EDITOR_TOKEN,
+        })
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, "Grafana API validation failed: Access denied - check API permissions")
+
+        gfconfig = GFConfig.objects.all()
+        self.assertTrue(gfconfig.count() == 0)
+
+
+
+
+

--- a/mercury/tests/test_gf_configs.py
+++ b/mercury/tests/test_gf_configs.py
@@ -31,9 +31,9 @@ class TestGFConfig(TestCase):
         self.gfconfig = GFConfig.objects.create(
             gf_name="Test", gf_host=HOST, gf_token=TOKEN, gf_current=True
         )
-        self.gf_config.save()
+        self.gfconfig.save()
         # Create fresh grafana object
-        self.grafana = Grafana(self.gf_config)
+        self.grafana = Grafana(self.gfconfig)
 
         # Create random name to be used for event and datasource
         self.event_name = self.grafana.generate_random_string(10)
@@ -45,7 +45,7 @@ class TestGFConfig(TestCase):
 
     def tearDown(self):
         # Create fresh grafana instance (in case test invalidated any tokens, etc.)
-        self.grafana = Grafana(self.gf_config)
+        self.grafana = Grafana(self.gfconfig)
 
         # Clear all of the created dashboards
         self.grafana.delete_dashboard_by_name(self.event_name)
@@ -74,7 +74,7 @@ class TestGFConfig(TestCase):
         )
         self.assertEqual(200, response.status_code)
 
-        gfconfig = GFConfig.objects.all()
+        gfconfig = GFConfig.objects.filter(gf_name="Test Grafana Instance")
         self.assertTrue(gfconfig.count() > 0)
         self.assertTrue(gfconfig[0].gf_name == "Test Grafana Instance")
         self.assertTrue(gfconfig[0].gf_host == HOST)

--- a/mercury/tests/test_gf_configs.py
+++ b/mercury/tests/test_gf_configs.py
@@ -1,12 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from mercury.models import EventCodeAccess, GFConfig
-from ag_data.models import AGSensor, AGSensorType, AGEvent, AGVenue
-from ag_data import simulator
 from mercury.grafanaAPI.grafana_api import Grafana
-import requests
-import os
-import datetime
 
 
 # default host and token, use this if user did not provide anything
@@ -67,12 +62,15 @@ class TestGrafana(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_config_post_success(self):
-        response = self.client.post(reverse(self.config_url), data={
-            "submit": "",
-            "gf_name": "Test Grafana Instance",
-            "gf_host": HOST,
-            "gf_token": TOKEN,
-        })
+        response = self.client.post(
+            reverse(self.config_url),
+            data={
+                "submit": "",
+                "gf_name": "Test Grafana Instance",
+                "gf_host": HOST,
+                "gf_token": TOKEN,
+            },
+        )
         self.assertEqual(200, response.status_code)
 
         gfconfig = GFConfig.objects.all()
@@ -82,12 +80,15 @@ class TestGrafana(TestCase):
         self.assertTrue(gfconfig[0].gf_token == TOKEN)
 
     def test_config_post_fail_invalid_API_key(self):
-        response = self.client.post(reverse(self.config_url), data={
-            "submit": "",
-            "gf_name": "Test Grafana Instance",
-            "gf_host": HOST,
-            "gf_token": "abcde",
-        })
+        response = self.client.post(
+            reverse(self.config_url),
+            data={
+                "submit": "",
+                "gf_name": "Test Grafana Instance",
+                "gf_host": HOST,
+                "gf_token": "abcde",
+            },
+        )
         self.assertEqual(200, response.status_code)
         self.assertContains(response, "Grafana API validation failed: Invalid API key")
 
@@ -95,19 +96,20 @@ class TestGrafana(TestCase):
         self.assertTrue(gfconfig.count() == 0)
 
     def test_config_post_fail_insufficient_permissions(self):
-        response = self.client.post(reverse(self.config_url), data={
-            "submit": "",
-            "gf_name": "Test Grafana Instance",
-            "gf_host": HOST,
-            "gf_token": EDITOR_TOKEN,
-        })
+        response = self.client.post(
+            reverse(self.config_url),
+            data={
+                "submit": "",
+                "gf_name": "Test Grafana Instance",
+                "gf_host": HOST,
+                "gf_token": EDITOR_TOKEN,
+            },
+        )
         self.assertEqual(200, response.status_code)
-        self.assertContains(response, "Grafana API validation failed: Access denied - check API permissions")
+        self.assertContains(
+            response,
+            "Grafana API validation failed: Access denied - check API permissions",
+        )
 
         gfconfig = GFConfig.objects.all()
         self.assertTrue(gfconfig.count() == 0)
-
-
-
-
-

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -7,8 +7,6 @@ from mercury.grafanaAPI.grafana_api import Grafana
 import requests
 import os
 import datetime
-import random
-import string
 
 
 # default host and token, use this if user did not provide anything
@@ -94,7 +92,7 @@ class TestGrafana(TestCase):
 
         # Create random name to be used for event and datasource
         self.event_name = self.grafana.generate_random_string(10)
-        self.datasource_name = "".join(random.choice(letters) for i in range(10))
+        self.datasource_name = self.grafana.generate_random_string(10)
 
         # Clear existing dashboard and datasource
         self.grafana.delete_dashboard_by_name(self.event_name)
@@ -132,7 +130,7 @@ class TestGrafana(TestCase):
         self.assertTrue(fetched_dashboard["dashboard"]["title"], self.event_name)
 
     def test_get_dashboard_fail(self):
-        uid = self.grafana.generate_random_string(10);
+        uid = self.grafana.generate_random_string(10)
 
         fetched_dashboard = self.grafana.get_dashboard_with_uid(uid)
 
@@ -222,7 +220,7 @@ class TestGrafana(TestCase):
         self.assertEquals(response.json()["message"], "Dashboard not found")
 
     def test_delete_grafana_dashboard_fail(self):
-        uid = self.grafana.generate_random_string(10);
+        uid = self.grafana.generate_random_string(10)
 
         # should return false if dashboard doesn't exist
         deleted_dashboard = self.grafana.delete_dashboard(uid)

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -127,14 +127,15 @@ class TestGrafana(TestCase):
         return response, session
 
     def test_get_dashboard_exists(self):
+        # Should return True if create_dashboard was successful
         dashboard = self.grafana.create_dashboard(self.event_name)
-
         self.assertTrue(dashboard)
 
+        # Query new dashboard
         uid = dashboard["uid"]
-
         fetched_dashboard = self.grafana.get_dashboard_with_uid(uid)
 
+        # Confirm params of new dashboard (slug, uid, title)
         self.assertTrue(fetched_dashboard)
         self.assertTrue(fetched_dashboard["meta"])
         self.assertTrue(fetched_dashboard["meta"]["slug"], self.event_name.lower())

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -12,15 +12,19 @@ import datetime
 # default host and token, use this if user did not provide anything
 HOST = "https://mercurytests.grafana.net"
 # this token has Admin level permissions
-TOKEN = (
-    "eyJrIjoiUm81MzlOUlRhalhGUFJ5OVVMNTZGTTZIdT"
-    "dvVURDSzIiLCJuIjoiYXBpX2tleSIsImlkIjoxfQ=="
-)
+
+# tokens for mercurytests
+TOKEN = "eyJrIjoiQzFMemVOQ0RDUExIcTdhbEluS0hPMDJTZXdKMWQyYTEiLCJuIjoiYXBpX2tleTIiLCJpZCI6MX0="
+
 # this token has Editor level permissions
 EDITOR_TOKEN = (
     "eyJrIjoibHlrZ2JWY0pnQk94b1YxSGYzd0NJ"
     "ZUdZa3JBeWZIT3QiLCJuIjoiZWRpdG9yX2tleSIsImlkIjoxfQ=="
 )
+DB_HOSTNAME = "ec2-35-168-54-239.compute-1.amazonaws.com:5432"
+DB_NAME = "d76k4515q6qv"
+DB_USERNAME = "qvqhuplbiufdyq"
+DB_PASSWORD = "f45a1cfe8458ff9236ead8a7943eba31dcef761471e0d6d62b043b4e3d2e10e5"
 
 
 # This test needs to have access to a test deployment of grafana, otherwise
@@ -55,7 +59,15 @@ class TestGrafana(TestCase):
     }
 
     def create_gfconfig(self):
-        config = GFConfig.objects.create(gf_host=HOST, gf_token=TOKEN, gf_current=True,)
+        config = GFConfig.objects.create(
+            gf_host=HOST,
+            gf_token=TOKEN,
+            gf_db_host=DB_HOSTNAME,
+            gf_db_name=DB_NAME,
+            gf_db_username=DB_USERNAME,
+            gf_db_pw=DB_PASSWORD,
+            gf_current=True,
+        )
         config.save()
         return config
 
@@ -88,7 +100,8 @@ class TestGrafana(TestCase):
         self._get_with_event_code(self.sensor_url, self.TESTCODE)
 
         # Create fresh grafana object
-        self.grafana = Grafana(HOST, TOKEN)
+        self.config = self.create_gfconfig()
+        self.grafana = Grafana(self.config)
 
         # Create random name to be used for event and datasource
         self.event_name = self.grafana.generate_random_string(10)
@@ -100,7 +113,7 @@ class TestGrafana(TestCase):
 
     def tearDown(self):
         # Create fresh grafana instance (in case test invalidated any tokens, etc.)
-        self.grafana = Grafana(HOST, TOKEN)
+        self.grafana = Grafana(self.config)
 
         # Clear all of the created dashboards
         self.grafana.delete_dashboard_by_name(self.event_name)

--- a/mercury/views/events.py
+++ b/mercury/views/events.py
@@ -147,8 +147,9 @@ class CreateEventsView(TemplateView):
             if gfconfig.count() > 0:
                 dashboard = None
                 # create a dashboard with the same name as the event
+                config = gfconfig[0]
                 try:
-                    grafana = Grafana()
+                    grafana = Grafana(config)
                     dashboard = grafana.create_dashboard(post_event_name)
                 except ValueError as error:
                     # pass any failure message from the API to the UI

--- a/mercury/views/gf_config.py
+++ b/mercury/views/gf_config.py
@@ -41,7 +41,7 @@ class GFConfigView(TemplateView):
             )
 
             # Create Grafana instance with host and token
-            grafana = Grafana(config_data.gf_host, config_data.gf_token)
+            grafana = Grafana(config_data)
             try:
                 grafana.validate_credentials()
                 config_data.gf_current = True


### PR DESCRIPTION
Add tests of GFConfig view to GET and POST from the view, confirm that expected error messages are displayed, confirm that a GFConfig object can be created successfully.

Also change Grafana class so that the constructor accepts a GFConfig object. Change any tests affected by this update. 

Fix issue with Grafana API tests which were causing > 5 dashboards to be created simultaneously (was causing Quota Reached error). Should get these changes over into frontend-team to avoid failures there (failures shouldn't hit master, because they were caused by these most recent changes surrounding Grafana's constructor taking a GFConfig object).