### PR TITLE
Grafana

### DIFF
--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -85,6 +85,23 @@ class Grafana:
 
         return True
 
+    def get_dashboard_by_event_name(self, event_name):
+        """
+        :param event_name: Event name used for the target dashboard.
+        :return: Returns True if a dashboard was found with this name, False otherwise.
+        """
+        # If there are spaces in the name, the GF API will replace them with dashes
+        # to generate the "slug". A slug can be used to query the API.
+        endpoint = os.path.join(
+            self.hostname, "api/dashboards/db", event_name.lower().replace(" ", "-"),
+        )
+        response = requests.get(url=endpoint, auth=("api_key", self.api_token))
+
+        if "dashboard" in response.json():
+            return response.json()
+        else:
+            return None
+
     def get_dashboard_with_uid(self, uid):
         """
         :param uid: uid of the target dashboard
@@ -313,18 +330,19 @@ class Grafana:
         except KeyError:
             return False
 
-    def add_panel(self, sensor, event, dashboard_uid):
+    def add_panel(self, sensor, event):
         """
 
         Adds a new panel for the sensor based on its SensorType.
         The database for the new panel will be whichever database is currently in
-        GFConfig. The panel will be placed in the next available slot on the dashboard.
+        GFConfig. The dashboard for the new panel will be the dashboard with the
+        same name as the event.
+        The panel will be placed in the next available slot on the dashboard.
 
         :param sensor: AGSensor object for this panel (panel will only display sensor
          data for this sensor type.
         :param event: Event object for this panel (panel will only display sensor
         data for this event)
-        :param dashboard_uid: UID of the target dashboard
 
         :return: New panel with SQL query based on sensor type
         will be added to dashboard.
@@ -338,11 +356,11 @@ class Grafana:
         for field in field_dict:
             field_array.append(field)
 
-        # Retrieve current dashboard structure
-        dashboard_info = self.get_dashboard_with_uid(dashboard_uid)
+        # Find dashboard uid for event
+        dashboard_info = self.get_dashboard_by_event_name(event.name)
 
         if dashboard_info is None:
-            raise ValueError("Dashboard uid not found.")
+            raise ValueError("Dashboard not found for this event.")
 
         # Retrieve current panels
         try:

--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -89,7 +89,7 @@ class Grafana:
         """
         :param uid: uid of the target dashboard
         :return:
-        Returns dashboard dictionary for given uid:
+        Returns dashboard dictionary for given uid or None if no dashboard was found.
         e.g. {
             'meta':
                 {
@@ -110,8 +110,6 @@ class Grafana:
                 'version': 1
             }
         }
-
-        Returns None if no dashboard is found.
         """
         headers = {"Content-Type": "application/json"}
         endpoint = os.path.join(self.endpoints["dashboard_uid"], uid)

--- a/mercury/tests/test_gf_configs.py
+++ b/mercury/tests/test_gf_configs.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.urls import reverse
 from mercury.models import EventCodeAccess, GFConfig
 from mercury.grafanaAPI.grafana_api import Grafana
-
+import os
 
 # default host and token, use this if user did not provide anything
 HOST = "https://mercurytests.grafana.net"
@@ -23,6 +23,8 @@ class TestGFConfig(TestCase):
         self.sensor_url = "mercury:sensor"
         self.event_url = "mercury:events"
         self.config_url = "mercury:gfconfig"
+        self.config_update_url = "mercury:gfconfig_update"
+        self.config_delete_url = "mercury:gfconfig_delete"
         test_code = EventCodeAccess(event_code="testcode", enabled=True)
         test_code.save()
         # Login
@@ -80,7 +82,7 @@ class TestGFConfig(TestCase):
         self.assertTrue(gfconfig[0].gf_host == HOST)
         self.assertTrue(gfconfig[0].gf_token == TOKEN)
 
-    def test_config_post_fail_invalid_API_key(self):
+    def test_config_post_fail_invalid_api_key(self):
         response = self.client.post(
             reverse(self.config_url),
             data={
@@ -114,3 +116,44 @@ class TestGFConfig(TestCase):
 
         gfconfig = GFConfig.objects.filter(gf_name="Test Grafana Instance")
         self.assertTrue(gfconfig.count() == 0)
+
+    def test_delete_config(self):
+        GFConfig.objects.all().delete()
+
+        gfconfig = GFConfig.objects.create(
+            gf_name="Test Grafana Instance", gf_host=HOST, gf_token=TOKEN
+        )
+        gfconfig.save()
+        gfconfig = GFConfig.objects.filter(gf_name="Test Grafana Instance").first()
+
+        self.client.post(
+            os.path.join(
+                reverse(self.config_delete_url, kwargs={"gf_id": gfconfig.id})
+            ),
+            data={
+                "submit": "",
+                "gf_name": "Test Grafana Instance",
+                "gf_host": HOST,
+                "gf_token": TOKEN,
+            },
+        )
+        gfconfig = GFConfig.objects.filter(gf_name="Test Grafana Instance")
+        self.assertTrue(gfconfig.count() == 0)
+
+    def test_update_config(self):
+        GFConfig.objects.all().delete()
+
+        gfconfig = GFConfig.objects.create(
+            gf_name="Test Grafana Instance",
+            gf_host=HOST,
+            gf_token=TOKEN,
+            gf_current=False,
+        )
+        gfconfig.save()
+
+        self.client.post(
+            os.path.join(reverse(self.config_update_url, kwargs={"gf_id": gfconfig.id}))
+        )
+
+        gfconfig = GFConfig.objects.all().first()
+        self.assertEquals(gfconfig.gf_current, True)

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -71,7 +71,7 @@ class TestGrafana(TestCase):
         config.save()
         return config
 
-    def create_venue_and_event(self):
+    def create_venue_and_event(self, event_name):
         venue = AGVenue.objects.create(
             name=self.test_venue_data["name"],
             description=self.test_venue_data["description"],
@@ -81,7 +81,7 @@ class TestGrafana(TestCase):
         venue.save()
 
         event = AGEvent.objects.create(
-            name=self.test_event_data["name"],
+            name=event_name,
             date=self.test_event_data["date"],
             description=self.test_event_data["description"],
             venue_uuid=venue,
@@ -258,8 +258,8 @@ class TestGrafana(TestCase):
         self.assertTrue(dashboard)
         uid = dashboard["uid"]
 
-        # Create an event
-        event = self.create_venue_and_event()
+        # Create an event and venue
+        event = self.create_venue_and_event(self.event_name)
 
         # Create a sensor type and sensor
         sensor_type = AGSensorType.objects.create(
@@ -294,8 +294,8 @@ class TestGrafana(TestCase):
         self.assertTrue(dashboard)
         uid = dashboard["uid"]
 
-        # Create an event
-        event = self.create_venue_and_event()
+        # Create an event and venue
+        event = self.create_venue_and_event(self.event_name)
 
         # Create a sensor type
         sensor_type = AGSensorType.objects.create(
@@ -331,7 +331,7 @@ class TestGrafana(TestCase):
         uid = self.grafana.generate_random_string(10)
 
         # Create an event
-        event = self.create_venue_and_event()
+        event = self.create_venue_and_event(self.event_name)
 
         # Create a sensor type and sensor
         sensor_type = AGSensorType.objects.create(
@@ -346,7 +346,7 @@ class TestGrafana(TestCase):
         sensor.save()
 
         # Check for expected ValueError and message
-        expected_message = "Dashboard uid not found."
+        expected_message = "Dashboard not found for this event."
         with self.assertRaisesMessage(ValueError, expected_message):
             self.grafana.add_panel(sensor, event, uid)
 

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -274,7 +274,7 @@ class TestGrafana(TestCase):
         sensor.save()
 
         # Add a panel to the dashboard
-        self.grafana.add_panel(sensor, event, uid)
+        self.grafana.add_panel(sensor, event)
 
         # Retrieve the current dashboard
         dashboard_info = self.grafana.get_dashboard_with_uid(uid)
@@ -312,7 +312,7 @@ class TestGrafana(TestCase):
             )
             sensor.save()
 
-            self.grafana.add_panel(sensor, event, uid)
+            self.grafana.add_panel(sensor, event)
 
         # Query dashboard to confirm 10 panels were added
         dashboard_info = self.grafana.get_dashboard_with_uid(uid)
@@ -348,7 +348,7 @@ class TestGrafana(TestCase):
         # Check for expected ValueError and message
         expected_message = "Dashboard not found for this event."
         with self.assertRaisesMessage(ValueError, expected_message):
-            self.grafana.add_panel(sensor, event, uid)
+            self.grafana.add_panel(sensor, event)
 
     def test_create_postgres_datasource(self):
         # Create datasource

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -326,9 +326,7 @@ class TestGrafana(TestCase):
             name = "".join([self.test_sensor_name, str(i)])
             self.assertTrue(dashboard_info["dashboard"]["panels"][i]["title"] == name)
 
-    def test_add_panel_fail_invalid_uid(self):
-        # Generate a random uid
-        uid = self.grafana.generate_random_string(10)
+    def test_add_panel_fail_no_dashboard_exists_for_event(self):
 
         # Create an event
         event = self.create_venue_and_event(self.event_name)

--- a/mercury/urls.py
+++ b/mercury/urls.py
@@ -33,6 +33,10 @@ urlpatterns = [
     path("events/export/<uuid:event_uuid>", events.export_event),
     path("pitcrew/", pitcrew.PitCrewView.as_view(), name="pitcrew"),
     path("gfconfig/", gf_config.GFConfigView.as_view(), name="gfconfig"),
-    path("gfconfig/delete/<int:gf_id>", gf_config.delete_config),
-    path("gfconfig/update/<int:gf_id>", gf_config.update_config),
+    path(
+        "gfconfig/delete/<int:gf_id>", gf_config.delete_config, name="gfconfig_delete"
+    ),
+    path(
+        "gfconfig/update/<int:gf_id>", gf_config.update_config, name="gfconfig_update"
+    ),
 ]

--- a/mercury/views/events.py
+++ b/mercury/views/events.py
@@ -161,13 +161,11 @@ class CreateEventsView(TemplateView):
 
                 # if a dashboard was created successfully, add panels to it
                 if dashboard:
-                    # retrieve dashboard uid
-                    dashboard_uid = dashboard["uid"]
                     # create a panel for each sensor
                     sensors = AGSensor.objects.all()
                     for sensor in sensors:
                         try:
-                            grafana.add_panel(sensor, event_data, dashboard_uid)
+                            grafana.add_panel(sensor, event_data)
                         except ValueError as error:
                             # pass any error messages from the API to the UI
                             messages.error(request, error)

--- a/mercury/views/gf_config.py
+++ b/mercury/views/gf_config.py
@@ -11,6 +11,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.ERROR)
 
 
+# Sets the GFConfig's current status to True
 def update_config(request, gf_id=None):
     GFConfig.objects.all().update(gf_current=False)
     GFConfig.objects.filter(id=gf_id).update(gf_current=True)

--- a/mercury/views/gf_config.py
+++ b/mercury/views/gf_config.py
@@ -57,6 +57,6 @@ class GFConfigView(TemplateView):
                 messages.error(request, f"Datasource couldn't be created. {error}")
 
             configs = GFConfig.objects.all().order_by("id")
-            config_form = GFConfigForm()
+            config_form = GFConfigForm(request.POST)
             context = {"config_form": config_form, "configs": configs}
             return render(request, self.template_name, context)


### PR DESCRIPTION
- Add more tests of GFConfig view: `update_config` and `delete_config` methods were previously untested.
- GFConfig view: pass form data back to the form if there is an error (so user doesn't have to retype form inputs). 
- Change Grafana API: Add function so that dashboards can be queried by name. Use this to change Grafana.add_panel() so that caller doesn't need to know dashboard UID, only event name when addinig a panel. Updated tests and error-handling to work with the update. 
- Change Create Sensors POST view: When a Sensor is created, if a `current` GFConfig exists and an event exists, add the sensor to the existing event (in the future, we are adding the concept of an Active event, but for now the new sensor will just be added to an event). 