### PR TITLE
Grafana

### DIFF
--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -57,6 +57,14 @@ class Grafana:
         self.base_panel_width = 15
         self.base_panel_height = 12
 
+    def create_safe_string(self, input):
+        """
+        Reformats the input string to be lowercase and with spaces replaced by '-'.
+        :param input: string
+        :return: reformatted string
+        """
+        return input.strip().lower().replace(" ","-")
+
     def generate_random_string(self, length):
         """
         Generates a random string of letters of given length.
@@ -107,8 +115,10 @@ class Grafana:
         """
         # If there are spaces in the name, the GF API will replace them with dashes
         # to generate the "slug". A slug can be used to query the API.
+        formatted_event_name = self.create_safe_string(event_name)
+
         endpoint = os.path.join(
-            self.hostname, "api/dashboards/db", event_name.lower().replace(" ", "-")
+            self.hostname, "api/dashboards/db", formatted_event_name
         )
         response = requests.get(url=endpoint, auth=("api_key", self.api_token))
 
@@ -118,9 +128,9 @@ class Grafana:
             return None
 
     def get_dashboard_url_by_name(self, name):
-        name = name.strip().lower().replace(" ", "-")
+        search_name = self.create_safe_string(name)
 
-        dashboard = self.get_dashboard_by_name(name)
+        dashboard = self.get_dashboard_by_name(search_name)
         if dashboard:
             endpoint = dashboard["meta"]["url"].strip("/")
             url = os.path.join(self.hostname, endpoint)
@@ -270,8 +280,9 @@ class Grafana:
         return False
 
     def delete_dashboard_by_name(self, name):
+        search_name = self.create_safe_string(name)
         endpoint = os.path.join(
-            self.hostname, "api/dashboards/db", name.lower().replace(" ", "-")
+            self.hostname, "api/dashboards/db", search_name
         )
         response = requests.get(url=endpoint, auth=("api_key", self.api_token))
 

--- a/mercury/grafanaAPI/grafana_api.py
+++ b/mercury/grafanaAPI/grafana_api.py
@@ -63,7 +63,7 @@ class Grafana:
         :param input: string
         :return: reformatted string
         """
-        return input.strip().lower().replace(" ","-")
+        return input.strip().lower().replace(" ", "-")
 
     def generate_random_string(self, length):
         """
@@ -281,9 +281,7 @@ class Grafana:
 
     def delete_dashboard_by_name(self, name):
         search_name = self.create_safe_string(name)
-        endpoint = os.path.join(
-            self.hostname, "api/dashboards/db", search_name
-        )
+        endpoint = os.path.join(self.hostname, "api/dashboards/db", search_name)
         response = requests.get(url=endpoint, auth=("api_key", self.api_token))
 
         dashboard = response.json().get("dashboard")

--- a/mercury/templates/events.html
+++ b/mercury/templates/events.html
@@ -124,6 +124,10 @@
             {% else %}
                     <div>There are no events to show.</div>
             {% endif %}
+
+            {% for message in messages %}
+            <p class="error"> {{ message }} </p>
+            {% endfor %}
         </div>
 
         <!--Create Events -->

--- a/mercury/tests/test_event.py
+++ b/mercury/tests/test_event.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.urls import reverse
-from mercury.models import EventCodeAccess, GFConfig
+from mercury.models import EventCodeAccess
 from ag_data.models import AGEvent, AGVenue
 import datetime
 
@@ -173,8 +173,9 @@ class TestEventView(TestCase):
         self.assertEquals(AGEvent.objects.all().count(), 1)
 
         # Delete the event
-        self.client.post(reverse(self.event_delete_url, kwargs={"event_uuid":
-                                                                    event.uuid}))
+        self.client.post(
+            reverse(self.event_delete_url, kwargs={"event_uuid": event.uuid})
+        )
 
         # Confirm that event was deleted
         self.assertEquals(AGEvent.objects.all().count(), 0)

--- a/mercury/tests/test_event.py
+++ b/mercury/tests/test_event.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.urls import reverse
-from mercury.models import EventCodeAccess
+from mercury.models import EventCodeAccess, GFConfig
 from ag_data.models import AGEvent, AGVenue
 import datetime
 
@@ -23,9 +23,34 @@ class TestEventView(TestCase):
         "longitude": 200,
     }
 
+    # Returns event
+    def create_venue_and_event(self, event_name):
+        venue = AGVenue.objects.create(
+            name=self.test_venue_data["name"],
+            description=self.test_venue_data["description"],
+            latitude=self.test_venue_data["latitude"],
+            longitude=self.test_venue_data["longitude"],
+        )
+        venue.save()
+
+        event = AGEvent.objects.create(
+            name=event_name,
+            date=self.test_event_data["date"],
+            description=self.test_event_data["description"],
+            venue_uuid=venue,
+        )
+        event.save()
+
+        return event
+
     def setUp(self):
         self.login_url = "mercury:EventAccess"
         self.event_url = "mercury:events"
+        self.event_delete_url = "mercury:delete_event"
+
+        # Create random event name
+        self.event_name = "test"
+
         test_code = EventCodeAccess(event_code=self.TESTCODE, enabled=True)
         test_code.save()
 
@@ -139,3 +164,17 @@ class TestEventView(TestCase):
         self.assertEqual(event.date, self.test_event_data["date"])
         self.assertEqual(event.venue_uuid.uuid, venue.uuid)
         self.assertEqual(event.description, self.test_event_data["description"])
+
+    def test_delete_event(self):
+        # Create an event
+        event = self.create_venue_and_event(self.event_name)
+
+        # Confirm that event was created
+        self.assertEquals(AGEvent.objects.all().count(), 1)
+
+        # Delete the event
+        self.client.post(reverse(self.event_delete_url, kwargs={"event_uuid":
+                                                                    event.uuid}))
+
+        # Confirm that event was deleted
+        self.assertEquals(AGEvent.objects.all().count(), 0)

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -344,7 +344,7 @@ class TestGrafana(TestCase):
         sensor_type.save()
 
         # POST sensor data
-        response = self.client.post(
+        self.client.post(
             reverse(self.sensor_url),
             data={
                 "submit_new_sensor": "",
@@ -365,8 +365,9 @@ class TestGrafana(TestCase):
 
         # Note: converting test_sensor_name to lowercase because currently
         # sensor names are automatically capitalized when they are created
-        self.assertEquals(dashboard["dashboard"]["panels"][0]["title"],
-                          self.test_sensor_name.lower())
+        self.assertEquals(
+            dashboard["dashboard"]["panels"][0]["title"], self.test_sensor_name.lower()
+        )
 
     def test_add_panel_fail_no_dashboard_exists_for_event(self):
 

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -543,7 +543,7 @@ class TestGrafana(TestCase):
             dashboard_info["dashboard"]["panels"][0]["title"] == sensor.name
         )
 
-    def test_delete_event_no_data_deletes_grafana_dashboard(self):
+    def test_delete_event_deletes_grafana_dashboard(self):
         self.grafana.create_postgres_datasource(self.datasource_name)
 
         # Create a venue
@@ -568,6 +568,9 @@ class TestGrafana(TestCase):
             },
         )
 
+        dashboard = self.grafana.get_dashboard_by_name(self.event_name)
+        self.assertTrue(dashboard)
+
         # Retrieve event object
         event = AGEvent.objects.all().first()
 
@@ -576,10 +579,5 @@ class TestGrafana(TestCase):
                                                                     event.uuid}))
         # Try and retrieve the dashboard
         dashboard = self.grafana.get_dashboard_by_name(self.event_name)
-        print(dashboard)
-        self.assertFalse(dashboard)
 
-    # Generate sample data for the event, this should prevent the dashboard from
-    # being deleted
-    def test_delete_event_data_keeps_grafana_dashboard(self):
-        self.assertTrue(False)
+        self.assertFalse(dashboard)

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -44,16 +44,6 @@ class TestGrafana(TestCase):
         "right_gust": {"unit": "km/h", "format": "float"},
     }
 
-    test_type_object_name = "test-sensor-object"
-    test_sensor = {"name": "wind speed sensor", "type_id": test_type_object_name}
-    demo_sensor_type = {
-        "type-name": "fuel level",
-        "processing formula": 0,
-        "field-names": ["test-field-1", "test-field-2"],
-        "data-types": ["test-data-type-1", "test-data-type-2"],
-        "units": ["test-unit-1", "test-unit-2"],
-    }
-
     test_event_data = {
         "name": "Sunny Day Test Drive",
         "date": datetime.datetime(2020, 2, 2, 20, 21, 22),
@@ -344,7 +334,7 @@ class TestGrafana(TestCase):
         self.assertTrue(dashboard)
 
         # Create an event
-        # self.create_venue_and_event(self.event_name)
+        self.create_venue_and_event(self.event_name)
 
         sensor_type = AGSensorType.objects.create(
             name=self.test_sensor_type,
@@ -358,22 +348,10 @@ class TestGrafana(TestCase):
             reverse(self.sensor_url),
             data={
                 "submit_new_sensor": "",
-                "sensor-name": self.test_sensor["name"],
+                "sensor-name": self.test_sensor_name,
                 "select-sensor-type": self.test_sensor_type,
             },
         )
-
-        """# POST sensor data
-        self.client.post(
-            reverse(self.sensor_url),
-            data={
-                "submit": "",
-                "type-name": self.demo_sensor_type["type-name"],
-                "field-names": self.demo_sensor_type["field-names"],
-                "data-types": self.demo_sensor_type["data-types"],
-                "units": self.demo_sensor_type["units"],
-            },
-        )"""
 
         # Fetch the dashboard again
         dashboard = self.grafana.get_dashboard_by_name(dashboard["slug"])
@@ -384,8 +362,11 @@ class TestGrafana(TestCase):
         self.assertTrue(dashboard["dashboard"])
         self.assertTrue(dashboard["dashboard"]["panels"])
         self.assertTrue(len(dashboard["dashboard"]["panels"]) == 1)
-        self.assertTrue(dashboard["dashboard"]["panels"][0]["title"] ==
-                        self.test_sensor_name)
+
+        # Note: converting test_sensor_name to lowercase because currently
+        # sensor names are automatically capitalized when they are created
+        self.assertEquals(dashboard["dashboard"]["panels"][0]["title"],
+                          self.test_sensor_name.lower())
 
     def test_add_panel_fail_no_dashboard_exists_for_event(self):
 

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -575,8 +575,9 @@ class TestGrafana(TestCase):
         event = AGEvent.objects.all().first()
 
         # Delete the event by posting to the delete view
-        self.client.post(reverse(self.event_delete_url, kwargs={"event_uuid":
-                                                                    event.uuid}))
+        self.client.post(
+            reverse(self.event_delete_url, kwargs={"event_uuid": event.uuid})
+        )
         # Try and retrieve the dashboard
         dashboard = self.grafana.get_dashboard_by_name(self.event_name)
 

--- a/mercury/urls.py
+++ b/mercury/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
         name="update_type",
     ),
     path("events/", events.CreateEventsView.as_view(), name="events"),
-    path("events/delete/<uuid:event_uuid>", events.delete_event),
+    path("events/delete/<uuid:event_uuid>", events.delete_event, name="delete_event"),
     path("events/update/<uuid:event_uuid>", events.update_event),
     path("events/updatevenue/<uuid:venue_uuid>", events.update_venue),
     path("events/export/<uuid:event_uuid>/csv", events.export_event),

--- a/mercury/views/events.py
+++ b/mercury/views/events.py
@@ -46,7 +46,27 @@ def update_event(request, event_uuid=None):
 
 def delete_event(request, event_uuid=None):
     event_to_delete = AGEvent.objects.get(uuid=event_uuid)
+
+    # delete any dashboards that exist for this event
+    gfconfigs = GFConfig.objects.all()
+
+    # Add panel to each grafana instance
+    for gfconfig in gfconfigs:
+
+        # Grafana instance using current GFConfig
+        grafana = Grafana(gfconfig)
+
+        deleted = grafana.delete_dashboard_by_name(event_to_delete.name)
+
+        if not deleted:
+            messages.error(
+                request,
+                f"Failed to delete Event dashboard from Grafana instance: "
+                f"{gfconfig.gf_host}"
+            )
+
     event_to_delete.delete()
+
     return redirect("/events")
 
 

--- a/mercury/views/events.py
+++ b/mercury/views/events.py
@@ -62,7 +62,7 @@ def delete_event(request, event_uuid=None):
             messages.error(
                 request,
                 f"Failed to delete Event dashboard from Grafana instance: "
-                f"{gfconfig.gf_host}"
+                f"{gfconfig.gf_host}",
             )
 
     event_to_delete.delete()

--- a/mercury/views/sensor.py
+++ b/mercury/views/sensor.py
@@ -287,7 +287,8 @@ class CreateSensorView(TemplateView):
                             grafana.add_panel(new_sensor, active_event)
                         except ValueError as error:
                             messages.error(
-                                request, f"Failed to add panel to active dashboard: {error}"
+                                request,
+                                f"Failed to add panel to active dashboard: {error}",
                             )
 
                 context = {"sensors": sensors, "sensor_types": sensor_types}

--- a/mercury/views/sensor.py
+++ b/mercury/views/sensor.py
@@ -253,6 +253,9 @@ class CreateSensorView(TemplateView):
             sensor_types = (
                 AGSensorType.objects.all()
             )  # for when we return context later
+
+            sensors = AGSensor.objects.all()
+
             if valid:
                 new_sensor = AGSensor.objects.create(
                     name=sensor_name, type_id=sensor_type
@@ -261,33 +264,32 @@ class CreateSensorView(TemplateView):
 
                 # Add a Sensor panel to the Active Event
 
-                # Check that Grafana is already configured
-                # and that an Active Event exists
-
                 # Note: THIS IS A PLACEHOLDER - waiting to decide
                 # how to implement Current GFConfig
-                gf_configs = GFConfig.objects.filter(gf_current=True)
+                gfconfigs = GFConfig.objects.all()
 
                 # Note: THIS IS A PLACEHOLDER - waiting to decide
                 # how to implement Active Event
                 active_events = AGEvent.objects.all()
 
-                if len(gf_configs) > 0 and len(active_events) > 0:
-                    gf_config = gf_configs.first()
+                # Only add panel to active event
+                if len(active_events) > 0:
                     active_event = active_events.first()
 
-                    # Grafana instance using current GFConfig
-                    grafana = Grafana(gf_config)
+                    # Add panel to each grafana instance
+                    for gfconfig in gfconfigs:
 
-                    # Add the Sensor Panel to the Active Event's dashboard
-                    try:
-                        grafana.add_panel(new_sensor, active_event)
-                    except ValueError as error:
-                        messages.error(
-                            request, f"Failed to add panel to active dashboard: {error}"
-                        )
+                        # Grafana instance using current GFConfig
+                        grafana = Grafana(gfconfig)
 
-                sensors = AGSensor.objects.all()
+                        # Add the Sensor Panel to the Active Event's dashboard
+                        try:
+                            grafana.add_panel(new_sensor, active_event)
+                        except ValueError as error:
+                            messages.error(
+                                request, f"Failed to add panel to active dashboard: {error}"
+                            )
+
                 context = {"sensors": sensors, "sensor_types": sensor_types}
             else:
                 sensors = AGSensor.objects.all()


### PR DESCRIPTION
- Test that adding a new sensor through the UI will create a dashboard in the "Active Event". In the current test only 1 event exists, and in the current implementation the active event == first event. (Once active event is actually added, more tests should be added to confirm that the sensor is added to only the active event.)
- Modify sensor post method to add the panel to each Grafana instance that exists, not just the first one found. 
- Refactor some code that was being reused in multiple places to do string formatting so that it is a method and can be called whenever needed. 
- Add a test for the Event view's delete view (delete_event) that creates an event by posting to the UI and confirms that an event object was created.
- When an Event is deleted through the UI (by posting to the delete_event view), if any Grafana instances have a dashboard for that event, the dashboard is deleted. 
- Add a test of the above new functionality.  