### PR TITLE
Adapt MeasurementExchange format

### DIFF
--- a/ag_data/formulas/ingestion_engine.py
+++ b/ag_data/formulas/ingestion_engine.py
@@ -1,10 +1,7 @@
-import attr
-
-from django.utils import timezone
-
 from ag_data import models
 from ag_data.formulas.library.system import mercury_formulas as hgFormulas
 
+from ag_data.utilities import MeasurementExchange
 
 class MeasurementIngestionEngine:
 
@@ -37,21 +34,3 @@ class MeasurementIngestionEngine:
         )
 
 
-@attr.s
-class MeasurementExchange(object):
-    event = attr.ib(kw_only=True, validator=attr.validators.instance_of(models.AGEvent))
-    timestamp = attr.ib(
-        kw_only=True, validator=attr.validators.instance_of(timezone.datetime)
-    )
-    sensor = attr.ib(
-        kw_only=True, validator=attr.validators.instance_of(models.AGSensor)
-    )
-    reading = attr.ib(kw_only=True, validator=attr.validators.instance_of(dict))
-
-    @property
-    def sensor_type(self):
-        return self.sensor.type_id
-
-    @property
-    def processing_formula(self):
-        return self.sensor_type.processing_formula

--- a/ag_data/formulas/ingestion_engine.py
+++ b/ag_data/formulas/ingestion_engine.py
@@ -1,3 +1,7 @@
+import attr
+
+from django.utils import timezone
+
 from ag_data import models
 from ag_data.formulas.library.system import mercury_formulas as hgFormulas
 
@@ -31,3 +35,23 @@ class MeasurementIngestionEngine:
         return models.AGMeasurement.objects.create(
             timestamp=timestamp, event_uuid=event, sensor_id=sensor, value=value
         )
+
+
+@attr.s
+class MeasurementExchange(object):
+    event = attr.ib(kw_only=True, validator=attr.validators.instance_of(models.AGEvent))
+    timestamp = attr.ib(
+        kw_only=True, validator=attr.validators.instance_of(timezone.datetime)
+    )
+    sensor = attr.ib(
+        kw_only=True, validator=attr.validators.instance_of(models.AGSensor)
+    )
+    reading = attr.ib(kw_only=True, validator=attr.validators.instance_of(dict))
+
+    @property
+    def sensor_type(self):
+        return self.sensor.type_id
+
+    @property
+    def processing_formula(self):
+        return self.sensor_type.processing_formula

--- a/ag_data/simulator.py
+++ b/ag_data/simulator.py
@@ -3,7 +3,10 @@ from random import gauss, random
 
 from django.utils import timezone
 
-from ag_data.formulas.ingestion_engine import MeasurementIngestionEngine
+from ag_data.formulas.ingestion_engine import (
+    MeasurementIngestionEngine,
+    MeasurementExchange,
+)
 from ag_data import utilities
 
 
@@ -21,13 +24,11 @@ class Simulator:
         utilities.assertEvent(self.event)
         utilities.assertSensor(self.sensor)
 
-        measurementDict = {
-            "measurement_timestamp": timestamp,
-            "measurement_sensor": self.sensor.id,
-            "measurement_values": value,
-        }
+        measurement_data = MeasurementExchange(
+            event=self.event, timestamp=timestamp, sensor=self.sensor, reading=value
+        )
 
-        return self.engine.saveMeasurement(measurementDict, self.event)
+        return self.engine.saveMeasurement(measurement_data)
 
     def logSingleMeasurement(self, timestamp):
 

--- a/ag_data/tests/test_ingestion_engine.py
+++ b/ag_data/tests/test_ingestion_engine.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+from django.utils import timezone
+
+from ag_data.models import AGVenue, AGEvent, AGSensorType, AGSensor, AGMeasurement
+from ag_data.presets import presets_generators
+from ag_data import utilities
+
+from ag_data.formulas.ingestion_engine import (
+    MeasurementIngestionEngine,
+    MeasurementExchange,
+)
+
+
+class MeasurementExchangeTest(TestCase):
+    def setUp(self):
+        self.venue = presets_generators.createVenueFromPresetAtIndex(0)
+        self.event = presets_generators.createEventFromPresetAtIndex(self.venue, 0)
+
+        utilities.createOrResetAllBuiltInSensorTypes()
+
+        self.sensor = presets_generators.createSensorFromPresetAtIndex(0)
+
+    def test_measurement_exchange_creation(self):
+        timestamp = timezone.now()
+        reading = {}
+
+        measurement_data = MeasurementExchange(
+            event=self.event, timestamp=timestamp, sensor=self.sensor, reading=reading
+        )
+
+        self.assertIs(measurement_data.event, self.event)
+        self.assertIs(measurement_data.timestamp, timestamp)
+        self.assertIs(measurement_data.sensor, self.sensor)
+        self.assertIs(measurement_data.reading, reading)
+
+        self.assertIs(measurement_data.sensor_type, self.sensor.type_id)
+        self.assertIs(measurement_data.processing_formula, self.sensor.type_id.processing_formula)
+

--- a/ag_data/tests/test_utilities_ingestion_engine.py
+++ b/ag_data/tests/test_utilities_ingestion_engine.py
@@ -1,14 +1,10 @@
 from django.test import TestCase
 from django.utils import timezone
 
-from ag_data.models import AGVenue, AGEvent, AGSensorType, AGSensor, AGMeasurement
 from ag_data.presets import presets_generators
 from ag_data import utilities
 
-from ag_data.formulas.ingestion_engine import (
-    MeasurementIngestionEngine,
-    MeasurementExchange,
-)
+from ag_data.formulas.ingestion_engine import MeasurementExchange
 
 
 class MeasurementExchangeTest(TestCase):

--- a/ag_data/tests/test_utilities_ingestion_engine.py
+++ b/ag_data/tests/test_utilities_ingestion_engine.py
@@ -34,5 +34,6 @@ class MeasurementExchangeTest(TestCase):
         self.assertIs(measurement_data.reading, reading)
 
         self.assertIs(measurement_data.sensor_type, self.sensor.type_id)
-        self.assertIs(measurement_data.processing_formula, self.sensor.type_id.processing_formula)
-
+        self.assertIs(
+            measurement_data.processing_formula, self.sensor.type_id.processing_formula
+        )

--- a/ag_data/utilities.py
+++ b/ag_data/utilities.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from ag_data import models
 from ag_data.presets.built_in_content import built_in_sensor_types
 
+
 @attr.s
 class MeasurementExchange(object):
     event = attr.ib(kw_only=True, validator=attr.validators.instance_of(models.AGEvent))
@@ -23,6 +24,7 @@ class MeasurementExchange(object):
     @property
     def processing_formula(self):
         return self.sensor_type.processing_formula
+
 
 def createOrResetAllBuiltInSensorTypes():
     for index in range(len(built_in_sensor_types)):

--- a/ag_data/utilities.py
+++ b/ag_data/utilities.py
@@ -1,6 +1,28 @@
+import attr
+
+from django.utils import timezone
+
 from ag_data import models
 from ag_data.presets.built_in_content import built_in_sensor_types
 
+@attr.s
+class MeasurementExchange(object):
+    event = attr.ib(kw_only=True, validator=attr.validators.instance_of(models.AGEvent))
+    timestamp = attr.ib(
+        kw_only=True, validator=attr.validators.instance_of(timezone.datetime)
+    )
+    sensor = attr.ib(
+        kw_only=True, validator=attr.validators.instance_of(models.AGSensor)
+    )
+    reading = attr.ib(kw_only=True, validator=attr.validators.instance_of(dict))
+
+    @property
+    def sensor_type(self):
+        return self.sensor.type_id
+
+    @property
+    def processing_formula(self):
+        return self.sensor_type.processing_formula
 
 def createOrResetAllBuiltInSensorTypes():
     for index in range(len(built_in_sensor_types)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ selenium==3.141.0
 django-annoying
 mock
 requests
+attr


### PR DESCRIPTION
Resolve #377 

Example usage:

```python
from ag_data.models import *
from ag_data.presets import presets_generators
from ag_data import utilities

from ag_data.formulas.ingestion_engine import MeasurementExchange
from django.utils import timezone

# create data
venue = presets_generators.createVenueFromPresetAtIndex(0)
event = presets_generators.createEventFromPresetAtIndex(venue, 0)
utilities.createOrResetAllBuiltInSensorTypes()
sensor = presets_generators.createSensorFromPresetAtIndex(0)

timestamp = timezone.now()

# create measurement exchange
measurement_data = MeasurementExchange(
    event=event, 
    timestamp=timestamp, 
    sensor=sensor, 
    reading={}
)
```