### PR TITLE
Introduce sensor simulation for sample GPS sensor

### DIFF
--- a/ag_data/presets.py
+++ b/ag_data/presets.py
@@ -44,9 +44,19 @@ sensor_type_presets = [
             "external": {"unit": "Keivin", "format": "float"},
         },
     },
+    {
+        "agSensorTypeID": 100,
+        "agSensorTypeName": "Violet GPS Sensor",
+        "agSensorTypeFormula": 0,
+        "agSensorTypeFormat": {
+            "latitude": {"unit": "degrees", "data_type": "Numeric"},
+            "longitude": {"unit": "degrees", "data_type": "Numeric"},
+        },
+    },
 ]
 
 sensor_presets = [
     {"agSensorName": "Sample Simple Temperature", "agSensorType": 0},
     {"agSensorName": "Sample Dual Temperature", "agSensorType": 1},
+    {"agSensorName": "Sunny's Violet GPS", "agSensorType": 2},
 ]

--- a/ag_data/simulator.py
+++ b/ag_data/simulator.py
@@ -193,6 +193,20 @@ class Simulator:
                 sensor_id=self.sensor,
                 value={"internal": gauss(15, 3), "external": gauss(20, 2)},
             )
+        elif self.checkSensorFormat(2):
+            import math
+
+            second = timestamp.second
+
+            x = math.cos(second / (2 * math.pi))
+            y = math.sin(second / (2 * math.pi))
+
+            return models.AGMeasurement.objects.create(
+                timestamp=timestamp,
+                event_uuid=self.event,
+                sensor_id=self.sensor,
+                value={"latitude": y, "longitude": x},
+            )
 
     def checkSensorFormat(self, index):
         return (

--- a/mercury/views/gps.py
+++ b/mercury/views/gps.py
@@ -22,4 +22,3 @@ class CreateGPSView(TemplateView):
         }
 
         return render(request, self.template_name, context)
-

--- a/mercury/views/gpspanels.py
+++ b/mercury/views/gpspanels.py
@@ -12,6 +12,7 @@ from mercury.event_check import require_event_code
 
 class CreateGPSPanelView(TemplateView):
     """This is the view for creating a new event."""
+
     template_name = "gpspanels.html"
 
     @require_event_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ selenium==3.141.0
 django-annoying
 mock
 requests
+matplotlib


### PR DESCRIPTION
This PR introduces a sensor with simulator support for a sample GPS sensor.

----

To use the simulator to create real-time measurement simulations:
```python
from ag_data.simulator import Simulator
from django.utils import timezone

sim = Simulator()

sim.createAVenueFromPresets(0)

sim.createAnEventFromPresets(0)

# create the Violet GPS Sensor Type
sim.createOrResetASensorTypeFromPresets(2) 

# create a Violet GPS sensor instance
sim.createASensorFromPresets(index = 2, cascadeCreation = False)

# create live measurements, set sleep time to 0 to execute infinitely
sim.logLiveMeasurements(frequencyInHz = 1, sleepTimer=10)
```

Or replace the last line of the above snippet to generate a bunch of old measurements:
```python
# log measurements in the past 3 minutes, with 1 measurement per second
sim.logMeasurementsInThePastSeconds(60 * 3, frequencyInHz = 1)
```