### PR TITLE
Feature/docker cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,10 +57,6 @@ jobs:
       
       services:
           - docker
-      
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get install -y -o Dpkg::Options::="--force-confold" docker-engine
 
       before_script:
         - docker pull nyumotorsportstelemetryorg/mercury || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ dist: xenial
 os: linux
 language: ruby
 
+env:
+  global:
+    - REGISTRY_USER=nyutelemetryrobot
+    # REGISTRY_PASS=...
+    - secure: "tzd1LpQ4MzCHB2FMSDjJec0hEi9SLrZHnILvNb1pj7P/agnFtUduC37aCcGSyrecfC4VF84wQNMYfndWn0L+M5XG1VWUuHcRYxJF7/F9ytkT91ZbZaUzaUy1m29up4C+jQdvYL4bR5WAMn330/SZiWF1Qr9N2DsLqGj4oYHOD6eOK9P1skmYK2CU5i1tjcjz0OOn2rxdGKTPxOwSg+8/OINYLVMkcK0iTAvPMXqR9UQjZqNmD+Z60HWEBF2xZuGXFXQ43sOilXrEY9FxrnQEFVeAJ5KzK9YSX38rJdTWasc0BFkyjSagFUCD9tvdQTc6+NOK4U7MLDCWJsMVwYnbV2tTmEA5bjPgocRsyX2+uBhEuSUW1RKP2MWtq0EmyYwnDHgpIWsuqnZlshtoA+ZEa7TcQsZqjjPqC6hBxVU32dVJDsUSwOLZ+xO+eyfb203az6PXldbetl48D5UN+qDRWlyr2T++IaZAGJHBNzkCMeyOURVhFnIxkFMEKB075PkKWf2M9cmN4hB3UTCNmo820Wpw1Cn2j/shMZ4KgKtnCXFDchGEpLzyUzdLeBZple5bPOGuw9xWUCn+V04kDewO0m/53DUz8xu+7bG7QFi4cFhqguPGge35ULnWPYgi+NkAW3BO1eAj8wgYB1gfZ10YNAjG4XYyaIrgTFh3h+SNwgk="
+
 jobs:
   include:
     # run django tests
@@ -53,14 +59,23 @@ jobs:
           - docker
         
       before_script:
+        - docker pull nyumotorsportstelemetryorg/mercury || true
+        
+      script:
         # prepare qemu for arm emulation on x64 hardware
         - docker run --rm --privileged multiarch/qemu-user-static:register --reset
         # build image
-        - docker build -t gcivil-nyu-org/spring2020-cs-gy-9223-class .
-        
-      script:
+        # - docker build -t gcivil-nyu-org/spring2020-cs-gy-9223-class .
+        - docker build --pull --cache-from nyumotorsportstelemetryorg/mercury --tag nyumotorsportstelemetryorg/mercury .
         # basic help world test to see if it's working
-        - docker run gcivil-nyu-org/spring2020-cs-gy-9223-class grep -q "Hello, Docker!" hello.txt
+        - docker run nyumotorsportstelemetryorg/mercury grep -q "Hello, Docker!" hello.txt
         # - black --check --exclude "migrations/" hardware
+      
+      before_deploy:
+        - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
+      
+      deploy:
+        provider: script
+        script: docker push nyumotorsportstelemetryorg/mercury
 
             

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,5 +78,5 @@ jobs:
         provider: script
         script: docker push nyumotorsportstelemetryorg/mercury
         on:
-          all_branches: true
+          branch: master
             

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,11 @@ jobs:
       
       services:
           - docker
-        
+      
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get install -y -o Dpkg::Options::="--force-confold" docker-engine
+
       before_script:
         - docker pull nyumotorsportstelemetryorg/mercury || true
         
@@ -70,6 +74,9 @@ jobs:
         # basic help world test to see if it's working
         - docker run nyumotorsportstelemetryorg/mercury grep -q "Hello, Docker!" hello.txt
         # - black --check --exclude "migrations/" hardware
+      
+      after_script:
+        - docker images
       
       before_deploy:
         - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,5 +77,6 @@ jobs:
       deploy:
         provider: script
         script: docker push nyumotorsportstelemetryorg/mercury
-
+        on:
+          all_branches: true
             

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM raspbian/stretch
 
 # install common build dependencies and clean up afterwards
+#RUN apt-get update && apt-get install -y --no-install-recommends \
+#    raspi-config \
+#    && rm -rf /var/lib/apt/lists/*
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    raspi-config \
-    && rm -rf /var/lib/apt/lists/*
+    raspi-config
 
 # copy setup scripts
 COPY ./hardware .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM raspbian/stretch
 
-# install common build dependencies
+# install common build dependencies and clean up afterwards
 RUN apt-get update && apt-get install -y --no-install-recommends \
     raspi-config \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM raspbian/stretch
 
 # install common build dependencies and clean up afterwards
-#RUN apt-get update && apt-get install -y --no-install-recommends \
-#    raspi-config \
-#    && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    raspi-config
+    raspi-config \
+    && rm -rf /var/lib/apt/lists/*
 
 # copy setup scripts
 COPY ./hardware .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM raspbian/stretch
 
 # install common build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    raspi-config
+    raspi-config \
+    && rm -rf /var/lib/apt/lists/*
 
 # copy setup scripts
 COPY ./hardware .


### PR DESCRIPTION
This PR enables the caching of our test docker images.  If there are no changes to the image as determined by docker, it will just pull the cached image resulting in a hugely faster build time.  On the master branch, if there are docker image differences, it will build the new one and then push it to the cache to be reused on future builds.