### PR TITLE
Tests

### DIFF
--- a/mercury/static/mercury/js/sensor.js
+++ b/mercury/static/mercury/js/sensor.js
@@ -13,10 +13,11 @@ $(document).ready(function () {
     $.ajax({
         url: `/sensor_data_exists/${sensor_id}`,
         type: "GET",
+        dataType: "json",
 
         success: function(response) {
 
-            var data = JSON.parse(response);
+            var data = response;
 
             if (data["status"] == true) {
                 runUpdateWarning(event, sensor_name);
@@ -38,7 +39,6 @@ function runUpdateWarning(event, sensor_name){
     var warning_id = `${sensor_name}-update-warning`;
     warning = document.getElementById(warning_id);
 
-    console.log('hide modify/update/delete buttons');
     // hide update button
     var update_button_id = `${sensor_name}-submit-button`;
     var delete_button_id = `${sensor_name}-delete-button`;

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -170,6 +170,14 @@ class TestGrafana(TestCase):
         self.assertTrue(fetched_dashboard["dashboard"]["uid"], uid)
         self.assertTrue(fetched_dashboard["dashboard"]["title"], self.event_name)
 
+    def test_get_dashboard_url_success(self):
+        self.grafana.create_dashboard(self.event_name)
+        self.assertTrue(self.grafana.get_dashboard_url_by_name(self.event_name))
+
+    def test_get_dashboard_url_none(self):
+        self.assertIsNone(self.grafana.get_dashboard_url_by_name(self.event_name +
+                                                                 "foo"))
+
     def test_get_dashboard_with_uid_fail(self):
         # Create a random UID to search for
         uid = self.grafana.generate_random_string(10)

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -395,6 +395,122 @@ class TestGrafana(TestCase):
             self.test_sensor["name"].lower(),
         )
 
+    def test_update_sensor_name_updates_panel_title(self):
+        # Create a dashboard
+        dashboard = self.grafana.create_dashboard(self.event_name)
+        self.assertTrue(dashboard)
+
+        # Create an event, create a sensor
+        event = self.create_venue_and_event(self.event_name)
+
+        # Create AGSensorType object for foreign key reference
+        sensor_type = AGSensorType.objects.create(
+            name=self.test_sensor["name"].lower(),
+            processing_formula=0,
+            format={
+                self.field_name_1: {"data_type": self.data_type_1, "unit": self.unit_1},
+                self.field_name_2: {"data_type": self.data_type_2, "unit": self.unit_2},
+            },
+        )
+        sensor_type.save()
+
+        # Create AG Sensor Object
+        sensor = AGSensor.objects.create(
+            name=self.test_sensor["name"].lower(), type_id=sensor_type
+        )
+        sensor.save()
+
+        # Add the sensor panel to the dashboard
+        self.grafana.add_panel(sensor, event)
+
+        updated_test_sensor_name = "foo"
+
+        # Post Edited Name
+        self.client.post(
+            reverse(self.sensor_url),
+            data={
+                "edit_sensor": "",
+                "sensor-name": self.test_sensor["name"].lower(),
+                "sensor-name-updated": updated_test_sensor_name,
+                "field-names": self.test_sensor["field-names"],
+                "data-types": self.test_sensor["data-types"],
+                "units": self.test_sensor["units"],
+            },
+        )
+
+        # Check that AGSensor object has new name
+        sensor = AGSensor.objects.all()[0]
+        self.assertEqual(sensor.name, updated_test_sensor_name)
+
+        # Check that sensor name was updated
+        sensor = AGSensor.objects.all()[0]
+        self.assertEquals(sensor.name, updated_test_sensor_name)
+
+        # Confirm that Grafana panel title was updated
+        # Confirm that a panel was added to the dashboard with the expected title
+        dashboard = self.grafana.get_dashboard_by_name(self.event_name)
+
+        self.assertTrue(dashboard)
+        self.assertTrue(dashboard["dashboard"])
+        self.assertTrue(dashboard["dashboard"]["panels"])
+        self.assertTrue(len(dashboard["dashboard"]["panels"]) == 1)
+
+        self.assertEquals(
+            dashboard["dashboard"]["panels"][0]["title"], updated_test_sensor_name,
+        )
+
+    def test_update_sensor_type_updates_panel_query(self):
+        # Create a dashboard, confirm it was created
+        dashboard = self.grafana.create_dashboard(self.event_name)
+        self.assertTrue(dashboard)
+
+        # Create an event
+        event = self.create_venue_and_event(self.event_name)
+
+        # Create sensor and sensor type
+        sensor_type = AGSensorType.objects.create(
+            name=self.test_sensor_name.lower(),
+            processing_formula=0,
+            format=self.test_sensor_format,
+        )
+        sensor_type.save()
+
+        sensor = AGSensor.objects.create(
+            name=self.test_sensor_name.lower(), type_id=sensor_type
+        )
+        sensor.save()
+
+        # Create grafana sensor panel
+        self.grafana.add_panel(sensor, event)
+
+        # New fields
+        field_names_updated = ["foo"]
+        data_types_updated = ["float"]
+        units_updated = ["km/h"]
+
+        # Post edited sensor type
+        self.client.post(
+            reverse(self.sensor_url),
+            data={
+                "edit_sensor": "",
+                "sensor-name": self.test_sensor["name"].lower(),
+                "sensor-name-updated": self.test_sensor["name"].lower(),
+                "field-names": field_names_updated,
+                "data-types": data_types_updated,
+                "units": units_updated,
+            },
+        )
+
+        # Confirm that a new Grafana panel was created with a query containing all of
+        # the current field names (not checking the full syntax of the query, just that
+        # the new field name is in the query)
+        dashboard = self.grafana.get_dashboard_by_name(self.event_name)
+
+        self.assertIn(
+            field_names_updated[0],
+            dashboard["dashboard"]["panels"][0]["targets"][0]["rawSql"],
+        )
+
     def test_delete_sensor_deletes_panel_in_dashboard(self):
         # Create a dashboard, confirm it was created
         dashboard = self.grafana.create_dashboard(self.event_name)

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -235,6 +235,21 @@ class TestGrafana(TestCase):
         # should return True if credentials are valid
         self.assertTrue(self.grafana.validate_credentials())
 
+    def test_update_dashboard_title_success(self):
+        event = self.create_venue_and_event(self.event_name)
+        self.grafana.create_dashboard(self.event_name)
+        new_name = event.name + " foo"
+        self.assertTrue(self.grafana.update_dashboard_title(event, new_name))
+
+    def test_update_dashboard_title_fail_same_name(self):
+        event = self.create_venue_and_event(self.event_name)
+        self.grafana.create_dashboard(self.event_name)
+        self.assertFalse(self.grafana.update_dashboard_title(event, event.name))
+
+    def test_update_dashboard_title_fail_no_dashboard(self):
+        event = self.create_venue_and_event(self.event_name)
+        self.assertFalse(self.grafana.update_dashboard_title(event, event.name))
+
     def test_validate_credentials_fail_authorization(self):
         self.grafana.api_token = "abcde"  # invalid API token
 

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -175,8 +175,9 @@ class TestGrafana(TestCase):
         self.assertTrue(self.grafana.get_dashboard_url_by_name(self.event_name))
 
     def test_get_dashboard_url_none(self):
-        self.assertIsNone(self.grafana.get_dashboard_url_by_name(self.event_name +
-                                                                 "foo"))
+        self.assertIsNone(
+            self.grafana.get_dashboard_url_by_name(self.event_name + "foo")
+        )
 
     def test_get_dashboard_with_uid_fail(self):
         # Create a random UID to search for

--- a/mercury/tests/test_grafana.py
+++ b/mercury/tests/test_grafana.py
@@ -565,7 +565,6 @@ class TestGrafana(TestCase):
             dashboard["dashboard"]["panels"][0]["targets"][0]["rawSql"],
         )
 
-
     def test_delete_sensor_deletes_panel_in_dashboard(self):
         # Create a dashboard, confirm it was created
         dashboard = self.grafana.create_dashboard(self.event_name)

--- a/mercury/tests/test_sensor_data.py
+++ b/mercury/tests/test_sensor_data.py
@@ -127,3 +127,13 @@ class TestSensorDataExistsView(TestCase):
         )
 
         self.assertEquals(response.json()["status"], True)
+
+    def test_sensor_data_sensor_id_not_found(self):
+        bad_id = 20
+
+        kwargs = {"sensor_id": bad_id}
+        response, session = self._get_with_event_code(
+            self.sensor_data_exists_url, self.TESTCODE, kwargs
+        )
+
+        self.assertEquals(response.json()["status"], False)

--- a/mercury/tests/test_sensor_data.py
+++ b/mercury/tests/test_sensor_data.py
@@ -1,0 +1,129 @@
+from django.test import TestCase
+from django.urls import reverse
+from mercury.models import EventCodeAccess
+from ag_data.models import AGSensor, AGSensorType, AGMeasurement, AGEvent, AGVenue
+import datetime
+
+
+class TestSensorDataExistsView(TestCase):
+
+    login_url = "mercury:login"
+    sensor_exists_url = "mercury:sensor_data_exists"
+    TESTCODE = "testcode"
+
+    event_name = "foo"
+
+    test_sensor_name = "Wind Sensor"
+    test_sensor_type = "Dual wind"
+
+    test_sensor_format = {
+        "left_gust": {"unit": "km/h", "format": "float"},
+        "right_gust": {"unit": "km/h", "format": "float"},
+    }
+
+    test_event_data = {
+        "name": "Sunny Day Test Drive",
+        "date": datetime.datetime(2020, 2, 2, 20, 21, 22),
+        "description": "A very progressive test run at \
+                        Sunnyside Daycare's Butterfly Room.",
+        "location": "New York, NY",
+    }
+
+    test_venue_data = {
+        "name": "Venue 1",
+        "description": "foo",
+        "latitude": 100,
+        "longitude": 200,
+    }
+
+    # Returns event
+    def create_venue_and_event(self, event_name):
+        venue = AGVenue.objects.create(
+            name=self.test_venue_data["name"],
+            description=self.test_venue_data["description"],
+            latitude=self.test_venue_data["latitude"],
+            longitude=self.test_venue_data["longitude"],
+        )
+        venue.save()
+
+        event = AGEvent.objects.create(
+            name=event_name,
+            date=self.test_event_data["date"],
+            description=self.test_event_data["description"],
+            venue_uuid=venue,
+        )
+        event.save()
+
+        return event
+
+    def _get_with_event_code(self, url, event_code, kwargs):
+        self.client.get(reverse(self.login_url))
+        self.client.post(reverse(self.login_url), data={"eventcode": event_code})
+        response = self.client.get(reverse(url, kwargs=kwargs))
+        session = self.client.session
+        return response, session
+
+    def setUp(self):
+        self.login_url = "mercury:EventAccess"
+        self.sensor_url = "mercury:sensor"
+        self.sensor_data_exists_url = "mercury:sensor_data_exists"
+        test_code = EventCodeAccess(event_code="testcode", enabled=True)
+        test_code.save()
+
+    def test_sensor_data_exists_no_measurements_for_sensor(self):
+        # Create a sensor type and sensor
+        sensor_type = AGSensorType.objects.create(
+            name=self.test_sensor_type,
+            processing_formula=0,
+            format=self.test_sensor_format,
+        )
+        sensor_type.save()
+        sensor = AGSensor.objects.create(
+            name=self.test_sensor_name, type_id=sensor_type
+        )
+        sensor.save()
+
+        kwargs = {"sensor_id": sensor.id}
+        self._get_with_event_code(self.sensor_data_exists_url, self.TESTCODE, kwargs)
+
+        # Create an event and venue
+        self.create_venue_and_event(self.event_name)
+
+        response = self.client.get(
+            reverse(self.sensor_data_exists_url, kwargs={"sensor_id": sensor.id})
+        )
+
+        self.assertEquals(response.json()["status"], False)
+
+    def test_sensor_data_exists_measurement_exists(self):
+        # Create a sensor type and sensor
+        sensor_type = AGSensorType.objects.create(
+            name=self.test_sensor_type,
+            processing_formula=0,
+            format=self.test_sensor_format,
+        )
+        sensor_type.save()
+        sensor = AGSensor.objects.create(
+            name=self.test_sensor_name, type_id=sensor_type
+        )
+        sensor.save()
+
+        kwargs = {"sensor_id": sensor.id}
+        self._get_with_event_code(self.sensor_data_exists_url, self.TESTCODE, kwargs)
+
+        # Create an event and venue
+        event = self.create_venue_and_event(self.event_name)
+
+        data = AGMeasurement.objects.create(
+            event_uuid=event,
+            sensor_id=sensor,
+            timestamp=datetime.datetime(2020, 2, 2, 20, 21, 22),
+            value={"left_gust": 10, "right_gust": 10},
+        )
+        data.save()
+
+        response = self.client.get(
+            reverse(self.sensor_data_exists_url, kwargs={"sensor_id": sensor.id})
+        )
+
+        self.assertEquals(response.json()["status"], True)

--- a/mercury/views/gf_config.py
+++ b/mercury/views/gf_config.py
@@ -43,7 +43,7 @@ def configure_dashboard(request, gf_id=None):
         current_dashboards = grafana.get_all_dashboards()
 
     except ValueError as error:
-        messages.error(request, f"Cannot to connect to Grafana: {error}")
+        messages.error(request, f"Cannot connect to Grafana: {error}")
         existing_events = []
         current_dashboards = []
 

--- a/mercury/views/sensor_data.py
+++ b/mercury/views/sensor_data.py
@@ -1,6 +1,5 @@
 import logging
-import json
-from django.http import HttpResponse
+from django.http import JsonResponse
 from ag_data.models import AGMeasurement
 
 log = logging.getLogger(__name__)
@@ -23,4 +22,4 @@ def get(request, sensor_id=None):
         True if AGMeasurement.objects.filter(sensor_id=sensor_id).count() > 0 else False
     )
 
-    return HttpResponse(json.dumps(response))
+    return JsonResponse(response)


### PR DESCRIPTION
# Add Grafana tests
- Add `test_update_sensor_name_and_type_updates_panel_title_and_query`, which updates a sensor's name and type at the same time, and confirms that both were updated. 
- Add tests of `Grafana.get_dashboard_url_by_name` helper method for both a successful query and an unsuccessful query.
- Add tests for `Grafana.update_dashboard_title` helper method, testing possible outcomes: 
  - dashboard title is updated successfully
  - dashboard update fails because the new name matches the existing name
  - dashboard update fails because dashboard doesn't exist.

# Add sensor_data_exists view tests
- `sensor_data_exists` returns `{"success": True}` when measurements exist for the target sensor
- `sensor_data_exists` returns `{"success": False"}` when no measurements exist for the sensor.
- `sensor_data_exists` returns `{"success": False"}` when the target sensor id doesn't match an existing sensor
