### PR TITLE
Add stringtype=unspecified to the template

### DIFF
--- a/symmetricds/README.md
+++ b/symmetricds/README.md
@@ -60,10 +60,11 @@ postgres://<username>:<password>@<url>
 ```
 db.user=<username>
 db.password=<password>
-db.url=jdbc:postgresql://<url>?sslmode=require
+db.url=jdbc:postgresql://<url>?sslmode=require&stringtype=unspecified
 ```
 
-Please make sure your db.url starts with `jdbc:postgresql://` and you appended `?sslmode=require` at the end.
+Please make sure your db.url starts with `jdbc:postgresql://` and you appended `?sslmode=require&stringtype=unspecified` at the end.
+To synchronize json fields, you should set `stringtype=unspecified`. Otherwise postgres assumes `varchar` by default. [Link](https://jdbc.postgresql.org/documentation/head/connect.html)
 
 For example, given the following output,
 ```
@@ -77,7 +78,7 @@ Your `engine1.properties` should be like:
 ```
 db.user=abcdeabcdefghi
 db.password=11d804e1c01111a9c111114fcc528753829a314c30cc51938f4192979102c12
-db.url=jdbc:postgresql://ec2-1-000-00-000.compute-2.amazonaws.com:5432/948f928kjfjv827?sslmode=require
+db.url=jdbc:postgresql://ec2-1-000-00-000.compute-2.amazonaws.com:5432/948f928kjfjv827?sslmode=require&stringtype=unspecified
 ```
 
 ### Step 3

--- a/symmetricds/template/engine0.properties
+++ b/symmetricds/template/engine0.properties
@@ -11,8 +11,10 @@ db.user=postgres
 db.password=
 
 # https://jdbc.postgresql.org/documentation/80/connect.html
-# db.url=jdbc:postgresql://localhost:5432/mercury
-db.url=jdbc:postgresql://localhost:5432/mercury
+# db.url=jdbc:postgresql://localhost:5432/mercury?stringtype=unspecified
+#
+# Set stringtype=unspecified to synchronize json fields. Otherwise postgres assumes varchar by default.
+db.url=jdbc:postgresql://localhost:5432/mercury?stringtype=unspecified
 
 
 

--- a/symmetricds/template/engine1.properties
+++ b/symmetricds/template/engine1.properties
@@ -13,9 +13,10 @@ registration.url=
 # 3. Your configuration would be:
 # db.user=<username>
 # db.password=<password>
-# db.url=jdbc:postgresql://<url>?sslmode=require
-
-# Please make sure your db.url starts with "jdbc:postgresql://" and you appended "?sslmode=require" at the end.
+# db.url=jdbc:postgresql://<url>?sslmode=require&stringtype=unspecified
+#
+# Please make sure your db.url starts with "jdbc:postgresql://" and you appended "?sslmode=require&stringtype=unspecified" at the end.
+# Set stringtype=unspecified to synchronize json fields. Otherwise postgres assumes varchar by default.
 
 db.user=
 db.password=


### PR DESCRIPTION
- Closes #348
- Append `stringtype=unspecified` at the end of the jdbc url in the `engine.properties` file in order to synchronize json fields.