### PR TITLE
Sync mercury_* tables

### DIFF
--- a/symmetricds/configure.sql
+++ b/symmetricds/configure.sql
@@ -45,7 +45,11 @@ insert into sym_node_group_link (source_node_group_id, target_node_group_id, dat
 
 insert into sym_trigger
 (trigger_id,source_table_name,channel_id,last_update_time,create_time)
-values('all_mercury_table_trigger','ag_*','main_channel',current_timestamp,current_timestamp);
+values('ag_table_trigger','ag_*','main_channel',current_timestamp,current_timestamp);
+
+insert into sym_trigger
+(trigger_id,source_table_name,channel_id,last_update_time,create_time)
+values('mercury_table_trigger','mercury_*','main_channel',current_timestamp,current_timestamp);
 
 ------------------------------------------------------------------------------
 -- Routers
@@ -67,8 +71,16 @@ values('group1_to_0', 'group1', 'group0', 'default',current_timestamp, current_t
 
 insert into sym_trigger_router
 (trigger_id,router_id,initial_load_order,last_update_time,create_time)
-values('all_mercury_table_trigger','group0_to_1', 100, current_timestamp, current_timestamp);
+values('mercury_table_trigger','group0_to_1', 100, current_timestamp, current_timestamp);
 
 insert into sym_trigger_router
 (trigger_id,router_id,initial_load_order,last_update_time,create_time)
-values('all_mercury_table_trigger','group1_to_0', 100, current_timestamp, current_timestamp);
+values('mercury_table_trigger','group1_to_0', 100, current_timestamp, current_timestamp);
+
+insert into sym_trigger_router
+(trigger_id,router_id,initial_load_order,last_update_time,create_time)
+values('ag_table_trigger','group0_to_1', 100, current_timestamp, current_timestamp);
+
+insert into sym_trigger_router
+(trigger_id,router_id,initial_load_order,last_update_time,create_time)
+values('ag_table_trigger','group1_to_0', 100, current_timestamp, current_timestamp);


### PR DESCRIPTION
## Title
Sync mercury_* tables

## Description
- Closes #547
- This PR provides symmetricDS configuration templates which make symmetricDS synchronize mercury_ prefixed tables i.e **mercury_gfconfig, mercury_eventcodeaccess**
- It is recommended to re-configure symmetricDS tables with the following command under `symmetricds` directory:
```
make clean-symd-table
make configure
```

## Types of Changes
- [x] Feature (non-breaking change which adds functionality)
- [ ] Bug Fix (non-breaking change that fixes an issue)
- [ ] Breaking Change (feature/fix that causes existing features to not work as expected)
- [ ] Documentation

## Checklist

- [ ] I have read the [contribute]contributing<link> doc
- [ ] Classes, scripts, and environment variables follow existing naming convention
- [ ] Lint and Unit tests pass locally
- [ ] New features on hardware have been tested on a local Raspberry Pi
- [ ] Mention new programs/binaries if any must be installed along with this change
- [ ] Mention new environment variables if any have been added to hardware/env file
- [ ] Test coverage should not drop more than 3%