### PR TITLE
Updated the default page to all events, in manage events.

### DIFF
--- a/mercury/templates/events.html
+++ b/mercury/templates/events.html
@@ -38,7 +38,7 @@
         </div>
 
     <!--Event Actions and Details -->
-        <div id="all-events" class="mt-50 hide-display">
+        <div id="all-events" class="mt-50">
             <h1>All Events</h1>
             {% if active_event %}
             <div>
@@ -287,7 +287,7 @@
 
 
         <!-- Help Document -->
-        <div id="help-events" class="mt-50 left-allign">
+        <div id="help-events" class="mt-50 left-allign hide-display">
             <h2 class="left-allign">1. All Events</h2>
             <p>Events can be considered as the identifier for the incoming data to the application from the vehicle. You can view
                 the existing events by clicking on All Events<br><br><b>You should see a table like below:</b>


### PR DESCRIPTION
## Title
Updated the default view in Manage Events to All events instead of help doc.

## Description
- _what is the purpose of this PR?_
to update the default view in manage events page.
- _what is the original vs the new behaviour?_
previously showing help doc, now showing all events.

## Types of Changes
_Put an `x` in the boxes that apply_

- [ ] Feature (non-breaking change which adds functionality)
- [ ] Bug Fix (non-breaking change that fixes an issue)
- [ ] Breaking Change (feature/fix that causes existing features to not work as expected)
- [ x] Documentation

## Checklist

- [x ] I have read the [contribute]contributing<link> doc
- [ x] Classes, scripts, and environment variables follow existing naming convention
- [ x] Lint and Unit tests pass locally
- [ x] New features on hardware have been tested on a local Raspberry Pi
- [ x] Mention new programs/binaries if any must be installed along with this change
- [ x] Mention new environment variables if any have been added to hardware/env file
- [ x] Please make sure test coverage does not drop. If it does, please explain the reasons.
- [ x] Any new required python modules are added to the requirements.txt